### PR TITLE
tox.ini: Simplify

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,13 +7,6 @@
 envlist = py26, py27, pypy, py33, py34
 
 [testenv]
-setenv =
-    TWIGGY_UNDER_TEST=1
+deps = -r{toxinidir}/test-requirements.txt
+setenv = TWIGGY_UNDER_TEST=1
 commands = py.test {posargs:--tb=short tests/}
-deps =
-    pytest
-
-[testenv:py26]
-deps =
-    pytest
-    unittest2


### PR DESCRIPTION
Mainly because unittest2 now works on Python 2 AND Python 3, so it can
be installed everywhere and not just for Python 2.6.

I also moved deps to `test-requirements.txt` so folks who are developing
and don't want to use `tox` can do `pip install -r
test-requirements.txt`.