### PR TITLE
tox.ini: Measure coverage

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist = py26, py27, pypy, py33, py34
 [testenv]
 deps = -r{toxinidir}/test-requirements.txt
 setenv = TWIGGY_UNDER_TEST=1
-commands = py.test {posargs:--tb=short tests/}
+commands = py.test {posargs:--tb=short --cov=twiggy --cov-report=xml --cov-report=html --cov-report=term-missing tests/}
 
 [testenv:flake8]
 basepython = python3.4

--- a/tox.ini
+++ b/tox.ini
@@ -10,3 +10,9 @@ envlist = py26, py27, pypy, py33, py34
 deps = -r{toxinidir}/test-requirements.txt
 setenv = TWIGGY_UNDER_TEST=1
 commands = py.test {posargs:--tb=short tests/}
+
+[testenv:flake8]
+basepython = python3.4
+commands =
+    pip install flake8
+    flake8 twiggy/ tests/

--- a/tox.ini
+++ b/tox.ini
@@ -7,13 +7,6 @@
 envlist = py26, py27, pypy, py33, py34
 
 [testenv]
-setenv =
-    TWIGGY_UNDER_TEST=1
+deps = -r{toxinidir}/test-requirements.txt
+setenv = TWIGGY_UNDER_TEST=1
 commands = py.test {posargs:--tb=short tests/}
-deps =
-    pytest
-
-[testenv:py26]
-deps =
-    pytest
-    unittest2


### PR DESCRIPTION
```
$ tox -e py34
...
--------------------------------------------------------------- coverage: platform darwin, python 3.4.0-final-0 ----------------------------------------------------------------
Name                       Stmts   Miss Branch BrMiss  Cover   Missing
----------------------------------------------------------------------
twiggy/__init__               34      0      6      0   100%
twiggy/compat                336    117    109     65    59%   52, 60-62, 88-90, 121-130, 140-142, 154, 169-170, 391, 399, 404-410, 433-435, 441-443, 448, 455, 458, 463, 483, 489, 495, 501, 513, 515, 518-519, 531, 534, 538, 540, 542, 554-556, 567-568, 579-630, 637, 641-652
twiggy/features/__init__       2      2      0      0     0%   2-3
twiggy/features/procinfo       5      5      0      0     0%   3-14
twiggy/features/socket         9      9      0      0     0%   2-25
twiggy/filters                52      0     26      0   100%
twiggy/formats                37      0      8      0   100%
twiggy/levels                 46      4     12      4    86%   33, 39, 45, 51
twiggy/lib/__init__            6      0      0      0   100%
twiggy/lib/converter          65      0     34      0   100%
twiggy/logger                136      9     18      0    94%   56, 159, 168-170, 180-182, 190-191
twiggy/logging_compat         79      2     14      0    98%   81, 159
twiggy/message                55      0     28      0   100%
twiggy/outputs                98      2      6      0    98%   120, 123
----------------------------------------------------------------------
TOTAL                        960    150    261     69    82%
Coverage HTML written to dir htmlcov
Coverage XML written to file coverage.xml
```

![screen shot 2015-01-15 at 7 13 39 pm](https://cloud.githubusercontent.com/assets/305268/5771077/bf8b3a9e-9cea-11e4-9f51-d6cbd1044596.png)
