### PR TITLE
tox.ini: Add doc target

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist = py26, py27, pypy, py33, py34
 [testenv]
 deps = -r{toxinidir}/test-requirements.txt
 setenv = TWIGGY_UNDER_TEST=1
-commands = py.test {posargs:--tb=short tests/}
+commands = py.test {posargs:--tb=short --cov=twiggy --cov-report=xml --cov-report=html --cov-report=term-missing tests/}
 
 [testenv:flake8]
 basepython = python3.4

--- a/tox.ini
+++ b/tox.ini
@@ -10,3 +10,9 @@ envlist = py26, py27, pypy, py33, py34
 deps = -r{toxinidir}/test-requirements.txt
 setenv = TWIGGY_UNDER_TEST=1
 commands = py.test {posargs:--tb=short tests/}
+
+[testenv:flake8]
+basepython = python3.4
+commands =
+    pip install flake8
+    flake8 twiggy/ tests/

--- a/tox.ini
+++ b/tox.ini
@@ -7,13 +7,6 @@
 envlist = py26, py27, pypy, py33, py34
 
 [testenv]
-setenv =
-    TWIGGY_UNDER_TEST=1
+deps = -r{toxinidir}/test-requirements.txt
+setenv = TWIGGY_UNDER_TEST=1
 commands = py.test {posargs:--tb=short tests/}
-deps =
-    pytest
-
-[testenv:py26]
-deps =
-    pytest
-    unittest2

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,11 @@ deps = -r{toxinidir}/test-requirements.txt
 setenv = TWIGGY_UNDER_TEST=1
 commands = py.test {posargs:--tb=short --cov=twiggy --cov-report=xml --cov-report=html --cov-report=term-missing tests/}
 
+[testenv:doc]
+deps = sphinx
+changedir = doc
+commands = sphinx-build . _build/html
+
 [testenv:flake8]
 basepython = python3.4
 commands =


### PR DESCRIPTION
```
❯ tox -e doc
GLOB sdist-make: /Users/marca/dev/git-repos/twiggy/setup.py
doc inst-nodeps: /Users/marca/dev/git-repos/twiggy/.tox/dist/Twiggy-0.4.5.zip
doc runtests: PYTHONHASHSEED='1895599405'
doc runtests: commands[0] | sphinx-build . _build/html
Running Sphinx v1.3b2
making output directory...
<string>:31: UserWarning: Couldn't import 'sphinxcontrib.googleanalytics
loading pickled environment... not yet created
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 9 source files that are out of date
updating environment: 9 added, 0 changed, 0 removed
/Users/marca/dev/git-repos/twiggy/.tox/doc/lib/python2.7/site-packages/twiggy/features/__init__.py:3: RuntimeWarning: Use of features is currently discouraged, pending refactoring
  warnings.warn("Use of features is currently discouraged, pending refactoring", RuntimeWarning)
reading sources... [100%] testing
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] testing
<autodoc>:None: WARNING: more than one target found for cross-reference u'socket': twiggy.features.socket, twiggy.features.socket.socket
generating indices... genindex
writing additional pages... search opensearch
copying static files... done
copying extra files... done
dumping search index in English (code: en) ... done
dumping object inventory... done
build succeeded, 1 warning.
___________________________________________________________________________________ summary ____________________________________________________________________________________
  doc: commands succeeded
  congratulations :)
```