### PR TITLE
Add blank line to quell sphinx warning

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -7,5 +7,6 @@ Glossary
 
     structured logging
         logging information in easy-to-parse key-value pairs, instead of embedded in a human-readable message. See an :ref:`example <structured-logging>`
+
     asynchronous logging
         performance enhancement that moves formatting and writing messages to a separate process. See :ref:`async-logging`.


### PR DESCRIPTION
This gets rid of the following sphinx warning:

    ...twiggy/doc/glossary.rst:79: WARNING: glossary term must be preceded by empty line