### PR TITLE
Support quickSetup but with DeprecationWarning

### DIFF
--- a/twiggy/__init__.py
+++ b/twiggy/__init__.py
@@ -1,5 +1,6 @@
-__all__=['log', 'emitters', 'add_emitters', 'devel_log', 'filters', 'formats', 'outputs', 'levels', 'quick_setup']
+__all__=['log', 'emitters', 'add_emitters', 'devel_log', 'filters', 'formats', 'outputs', 'levels', 'quick_setup', 'quickSetup']
 import time
+import warnings
 import sys
 import os
 
@@ -59,6 +60,12 @@ def quick_setup(min_level=levels.DEBUG, file = None, msg_buffer = 0):
         output = outputs.FileOutput(file, format=formats.line_format, msg_buffer=msg_buffer, mode='a')
 
     emitters['*'] = filters.Emitter(min_level, True, output)
+
+def quickSetup(*args, **kwargs):
+    warnings.warn(
+        "twiggy.quickSetup deprecated in favor of twiggy.quick_setup",
+        DeprecationWarning, stacklevel=2)
+    return quick_setup(*args, **kwargs)
 
 def add_emitters(*tuples):
     """Add multiple emitters.


### PR DESCRIPTION
Going from `maint-0.4` to `master`, `twiggy.quickSetup` has been renamed to `twiggy.quick_setup`. This makes `twiggy.quickSetup` work so that old code continues to work but using it will emit a `DeprecationWarning` if they are turned on.

```
$ python -W all example.py
example.py:5: DeprecationWarning: twiggy.quickSetup deprecated in favor of twiggy.quick_setup
  quickSetup()
INFO:frank:number=42|hello world, it's a sunny day
INFO:donjuan:pants=sexy|hello, ladies want to dance?
```