### PR TITLE
Make 0.4.7 the same level as other headers.

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -13,6 +13,7 @@ Changelog
 - PEP8 name compliance
 - add logging_compat module for compatibility with stlib's logging
 
+******************************
 0.4.7
 ******************************
 *03/09/2015*


### PR DESCRIPTION
Petern, please, accept this minor pull-request, as it breaks [allmychanges parsing](https://allmychanges.com/p/python/twiggy/) of twiggy's release notes.