### PR TITLE
Fixes up test_logging_compat setup/teardown

### DIFF
--- a/tests/test_logging_compat.py
+++ b/tests/test_logging_compat.py
@@ -2,11 +2,11 @@ import os
 import sys
 from unittest import TestCase
 
-def setup_module():
+def setUpModule():
     from twiggy import _populate_globals
     _populate_globals()
 
-def teardown_module():
+def tearDownModule():
     from twiggy import _del_globals
     _del_globals()
 


### PR DESCRIPTION
The function names were specified incorrectly, unittest is looking for
setUpModule and tearDownModule, not as they were given in this file.