### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,13 @@ matrix:
     - python: pypy3
       env: TOXENV=pypy3
     - python: 3.6
-      env: TOXENV=flake8
+      env: TOXENV=py3flake8
+    - python: 2.7
+      env: TOXENV=py2flake8
+    - python: 3.6
+      env: TOXENV=py3pyflakes
+    - python: 2.7
+      env: TOXENV=py2pyflakes
 
 install:
   - travis_retry pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,25 @@
 language: python
-
 sudo: false
-env:
-  - TOXENV=py26
-  - TOXENV=py27
-  - TOXENV=py33
-  - TOXENV=py34
-  - TOXENV=pypy
+matrix:
+  include:
+    - python: 2.6
+      env: TOXENV=py26
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.3
+      env: TOXENV=py33
+    - python: 3.4
+      env: TOXENV=py34
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36
+    - python: pypy
+      env: TOXENV=pypy
+    - python: pypy3
+      env: TOXENV=pypy3
+    - python: 3.6
+      env: TOXENV=flake8
 
 install:
   - travis_retry pip install tox

--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,29 @@ deps = sphinx
 changedir = doc
 commands = sphinx-build . _build/html
 
-[testenv:flake8]
+# Run /bin/true last so that we get logs of things to fix but don't fail the build (yet)
+[testenv:py3flake8]
 basepython = python3.6
 commands =
     pip install flake8
-    flake8 twiggy/ tests/
+    sh -c "flake8 twiggy/ tests/ || :"
+
+[testenv:py2flake8]
+basepython = python2.7
+commands =
+    pip install flake8
+    sh -c "flake8 twiggy/ tests/ || :"
+
+# Run pyflakes separate from flake8 for now as we should fix these quickly but
+# pep8 might take longer
+[testenv:py3pyflakes]
+basepython = python3.6
+commands =
+    pip install pyflakes
+    sh -c "pyflakes twiggy/ tests/ || :"
+
+[testenv:py2pyflakes]
+basepython = python2.7
+commands =
+    pip install pyflakes
+    sh -c "pyflakes twiggy/ tests/ || :"

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, pypy, py33, py34
+envlist = py26, py27, pypy, pypy3, py33, py34, py35, py36
 
 [testenv]
 deps = -r{toxinidir}/test-requirements.txt
@@ -17,7 +17,7 @@ changedir = doc
 commands = sphinx-build . _build/html
 
 [testenv:flake8]
-basepython = python3.4
+basepython = python3.6
 commands =
     pip install flake8
     flake8 twiggy/ tests/


### PR DESCRIPTION
This PR fixes the travis build (it was broken because travis was no longer installing the python versions which were being tested by default).

It also:

* Tests additional python versions (Now testing python 2.6, 2.7, 3.3, 3.4, 3.6, 3.6, pypy, and pypy3)
* Enables running pyflakes and flake8 but do not let them error the build.  (This way we get logs of what needs fixing but don't have to fix them until later).
