### PR TITLE
Fix pep8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,6 @@ matrix:
       env: TOXENV=py3flake8
     - python: 2.7
       env: TOXENV=py2flake8
-    - python: 3.6
-      env: TOXENV=py3pyflakes
-    - python: 2.7
-      env: TOXENV=py2pyflakes
 
 install:
   - travis_retry pip install tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,8 @@
+[flake8]
+max-line-length = 100
+
+[pycodestyle]
+max-line-length = 100
+
+[pep8]
+max-line-length = 100

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,11 +6,12 @@ import twiggy
 # an arbitrary but consistent time
 when = time.struct_time((2010, 10, 28, 2, 15, 57, 3, 301, 0))
 
+
 def make_mesg():
     return Message(twiggy.levels.DEBUG,
                    "Hello {0} {who}",
-                   {'shirt':42, 'name': 'jose'},
+                   {'shirt': 42, 'name': 'jose'},
                    Message._default_options,
                    args=["Mister"],
-                   kwargs={'who':"Funnypants"},
+                   kwargs={'who': "Funnypants"},
                    )

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,19 +1,23 @@
 import sys
+
+from twiggy.lib.converter import Converter, ConversionTable, same_item, same_value, drop
+
 if sys.version_info >= (2, 7):
     import unittest
 else:
-    try: 
+    try:
         import unittest2 as unittest
     except ImportError:
         raise RuntimeError("unittest2 is required for Python < 2.7")
-        
-from twiggy.lib.converter import Converter, ConversionTable, same_item, same_value, drop
+
 
 def conv_val(x):
     return x
 
+
 def conv_item(x, y):
     return x, y
+
 
 class HelperTestCase(unittest.TestCase):
 
@@ -27,16 +31,18 @@ class HelperTestCase(unittest.TestCase):
     def test_same_item(self):
         o1 = object()
         o2 = object()
-        
-        x1, x2 = same_item(o1, o2) 
+
+        x1, x2 = same_item(o1, o2)
         assert o1 is x1
         assert o2 is x2
+
 
 class ConverterTestCase(unittest.TestCase):
 
     def test_repr(self):
         c = Converter("pants", conv_val, conv_item)
         assert repr(c) == "<Converter('pants')>"
+
 
 class ConversionTableTestCase(unittest.TestCase):
 
@@ -112,13 +118,12 @@ class ConversionTableTestCase(unittest.TestCase):
 
     def test_get(self):
         c = Converter("pants", conv_val, conv_item)
-        
+
         ct = ConversionTable([c,
                               ("shirt", conv_val, conv_item, True)])
 
         assert ct.get("belt") is None
         assert ct.get("pants") is c
-
 
     def test_get_all_no_match(self):
         ct = ConversionTable([("pants", conv_val, conv_item),
@@ -132,30 +137,29 @@ class ConversionTableTestCase(unittest.TestCase):
         ct = ConversionTable([
             ("joe", "I wear {0}".format, conv_item),
             ("frank", "You wear {0}".format, conv_item)])
-        
+
         ct.generic_value = "Someone wears {0}".format
-        
-        d = ct.convert({'joe':'pants', 'frank':'shirt', 'bob':'shoes'})
+
+        d = ct.convert({'joe': 'pants', 'frank': 'shirt', 'bob': 'shoes'})
         self.assertDictEqual(d, {'joe': "I wear pants", 'frank': "You wear shirt", 'bob': "Someone wears shoes"})
 
     def test_drop(self):
         ct = ConversionTable([
             ("joe", "I wear {0}".format, conv_item),
             ("frank", "You wear {0}".format, lambda k, v: None)])
-        
-        ct.generic_item = drop
-        
-        d = ct.convert({'joe':'pants', 'frank':'shirt', 'bob':'shoes'})
-        assert d == {'joe': "I wear pants"}
 
+        ct.generic_item = drop
+
+        d = ct.convert({'joe': 'pants', 'frank': 'shirt', 'bob': 'shoes'})
+        assert d == {'joe': "I wear pants"}
 
     def test_generic(self):
         c = Converter("pants", conv_val, conv_item)
         ct = ConversionTable([c])
-        assert ct.convert({'shirt':42}) == {'shirt':42}
+        assert ct.convert({'shirt': 42}) == {'shirt': 42}
 
     def test_missing(self):
         c = Converter("pants", conv_val, conv_item, True)
         ct = ConversionTable([c])
         with self.assertRaises(ValueError):
-            ct.convert({'shirt':42}) == {'shirt':42}
+            ct.convert({'shirt': 42}) == {'shirt': 42}

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -141,7 +141,9 @@ class ConversionTableTestCase(unittest.TestCase):
         ct.generic_value = "Someone wears {0}".format
 
         d = ct.convert({'joe': 'pants', 'frank': 'shirt', 'bob': 'shoes'})
-        self.assertDictEqual(d, {'joe': "I wear pants", 'frank': "You wear shirt", 'bob': "Someone wears shoes"})
+        self.assertDictEqual(d, {'joe': "I wear pants",
+                                 'frank': "You wear shirt",
+                                 'bob': "Someone wears shoes"})
 
     def test_drop(self):
         ct = ConversionTable([

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,22 +1,23 @@
 import sys
-if sys.version_info >= (2, 7):
-    import unittest
-else:
-    try: 
-        import unittest2 as unittest
-    except ImportError:
-        raise RuntimeError("unittest2 is required for Python < 2.7")
-
 import re
 
 from twiggy import filters, levels
 
 from . import make_mesg
 
+if sys.version_info >= (2, 7):
+    import unittest
+else:
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        raise RuntimeError("unittest2 is required for Python < 2.7")
+
+
 m = make_mesg()
 
-class MsgFilterTestCase(unittest.TestCase):
 
+class MsgFilterTestCase(unittest.TestCase):
     # XXX more robust testing of the exact type/func.__name__ of the returned f
     # might be nice (instead of just callable), but eh.
 
@@ -52,10 +53,13 @@ class MsgFilterTestCase(unittest.TestCase):
         assert callable(f)
         assert not f(m)
 
+    @staticmethod
+    def _always_true(mesg):
+        return True
+
     def test_callable(self):
-        my_func = lambda mesg: True
-        f = filters.msg_filter(my_func)
-        assert f is my_func
+        f = filters.msg_filter(self._always_true)
+        assert f is self._always_true
 
     def test_bad_arg(self):
         with self.assertRaises(ValueError):
@@ -68,7 +72,7 @@ class MsgFilterTestCase(unittest.TestCase):
         f = filters.msg_filter(l)
         assert callable(f)
         assert f(m)
-        
+
         re3 = "^.*Sillyhead$"
         l = (re1, re3)
         f = filters.msg_filter(l)
@@ -83,7 +87,7 @@ class MsgFilterTestCase(unittest.TestCase):
         f = filters.msg_filter(l)
         assert callable(f)
         assert f(m)
-        
+
     def test_single_list(self):
         re1 = "^Hello.*$"
         l = [re1]
@@ -107,6 +111,7 @@ class namesTestCase(unittest.TestCase):
 
         assert filters.glob_names("jo*", "frank")(m)
         assert not filters.glob_names("*bob", "frank")(m)
+
 
 class EmitterTestCase(unittest.TestCase):
 

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,26 +1,27 @@
 import sys
-if sys.version_info >= (2, 7):
-    import unittest
-else:
-    try: 
-        import unittest2 as unittest
-    except ImportError:
-        raise RuntimeError("unittest2 is required for Python < 2.7")
 import copy
 
 from twiggy import formats, levels, message
 
 from . import when
-   
+
+if sys.version_info >= (2, 7):
+    import unittest
+else:
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        raise RuntimeError("unittest2 is required for Python < 2.7")
+
+
 class ConversionsTestCase(unittest.TestCase):
-   
-    fields = {
-        'time': when,
-        'level': levels.INFO,
-        'name': 'mylog',
-        'pants': 42,
-        }
-   
+
+    fields = {'time': when,
+              'level': levels.INFO,
+              'name': 'mylog',
+              'pants': 42,
+              }
+
     def test_line_conversion(self):
         d = self.fields.copy()
         assert formats.line_format.conversion.convert(d) == '2010-10-28T02:15:57Z:INFO:mylog:pants=42'
@@ -33,8 +34,7 @@ class ConversionsTestCase(unittest.TestCase):
 
         del d['level']
         with self.assertRaises(ValueError):
-            formats.line_format.conversion.convert(d) 
-
+            formats.line_format.conversion.convert(d)
 
     def test_shell_conversion(self):
         d = self.fields.copy()
@@ -48,94 +48,92 @@ class ConversionsTestCase(unittest.TestCase):
 
         del d['level']
         with self.assertRaises(ValueError):
-            formats.shell_format.conversion.convert(d) 
+            formats.shell_format.conversion.convert(d)
 
 
 class FormatTestCase(unittest.TestCase):
 
-    fields = {
-        'time': when,
-        'level': levels.INFO,
-        'name': 'mylog',
-        'pants': 42,
-        }
+    fields = {'time': when,
+              'level': levels.INFO,
+              'name': 'mylog',
+              'pants': 42,
+              }
 
     def test_copy(self):
         my_format = copy.copy(formats.line_format)
         assert my_format.separator == formats.line_format.separator
         assert my_format.traceback_prefix == formats.line_format.traceback_prefix
-        
+
         # XXX it'd be nice to test the guts of the conversion for equality, but Converters don't support that
         assert my_format.conversion is not formats.line_format.conversion
-    
+
     def test_basic(self):
-        
+
         fmt = formats.LineFormat(separator='|', conversion=formats.line_conversion)
-        
-        opts = message.Message._default_options.copy()       
-        msg = message.Message(levels.INFO, "I wear {0}", self.fields, opts, ['pants'], {})       
+
+        opts = message.Message._default_options.copy()
+        msg = message.Message(levels.INFO, "I wear {0}", self.fields, opts, ['pants'], {})
         assert fmt(msg) == '2010-10-28T02:15:57Z:INFO:mylog:pants=42|I wear pants\n'
-        
+
     def test_suppress_newline_true(self):
-        
+
         fmt = formats.LineFormat(separator='|', conversion=formats.line_conversion)
-        
+
         fields = self.fields.copy()
         fields['shirt'] = 'extra\nlarge'
-        
-        opts = message.Message._default_options.copy()       
+
+        opts = message.Message._default_options.copy()
         opts['suppress_newlines'] = True
-        msg = message.Message(levels.INFO, "I wear {0}\nDo you?", fields, opts, ['pants'], {})       
+        msg = message.Message(levels.INFO, "I wear {0}\nDo you?", fields, opts, ['pants'], {})
         s = fmt(msg)
 
         assert s == '2010-10-28T02:15:57Z:INFO:mylog:pants=42:shirt=extra\\nlarge|I wear pants\\nDo you?\n', repr(s)
-    
+
     def test_suppress_newline_false(self):
-        
+
         fmt = formats.LineFormat(separator='|', conversion=formats.line_conversion)
-        
+
         fields = self.fields.copy()
-        fields['shirt'] = 'extra\nlarge'        
-        
-        opts = message.Message._default_options.copy()       
+        fields['shirt'] = 'extra\nlarge'
+
+        opts = message.Message._default_options.copy()
         opts['suppress_newlines'] = False
-        msg = message.Message(levels.INFO, "I wear {0}\nDo you?", fields, opts, ['pants'], {})       
+        msg = message.Message(levels.INFO, "I wear {0}\nDo you?", fields, opts, ['pants'], {})
         s = fmt(msg)
         assert s == '2010-10-28T02:15:57Z:INFO:mylog:pants=42:shirt=extra\nlarge|I wear pants\nDo you?\n', repr(s)
-        
-    
+
     def test_trace(self):
-        
+
         fmt = formats.LineFormat(separator='|', conversion=formats.line_conversion)
-        
-        opts = message.Message._default_options.copy()       
+
+        opts = message.Message._default_options.copy()
         opts['trace'] = 'error'
-        
+
         try:
-            1/0
+            1 / 0
         except:
-            msg = message.Message(levels.INFO, "I wear {0}", self.fields, opts, ['pants'], {})       
-        
+            msg = message.Message(levels.INFO, "I wear {0}", self.fields, opts, ['pants'], {})
+
         s = fmt(msg)
         l = s.split('\n')
         assert len(l) == 6
         for i in l[1:-1]:
             assert i.startswith('TRACE')
-            
+
         assert l[0] == '2010-10-28T02:15:57Z:INFO:mylog:pants=42|I wear pants'
-            
+
     def test_trace_fold(self):
-        
-        fmt = formats.LineFormat(separator='|', traceback_prefix = '\\n', conversion=formats.line_conversion)
-        
-        opts = message.Message._default_options.copy()       
+
+        fmt = formats.LineFormat(separator='|', traceback_prefix='\\n', conversion=formats.line_conversion)
+
+        opts = message.Message._default_options.copy()
         opts['trace'] = 'error'
-        
+
         try:
-            1/0
+            1 / 0
         except:
-            msg = message.Message(levels.INFO, "I wear {0}", self.fields, opts, ['pants'], {})       
-        
+            msg = message.Message(levels.INFO, "I wear {0}", self.fields, opts, ['pants'], {})
+
         s = fmt(msg)
         l = s.split('\n')
         assert len(l) == 2

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -24,7 +24,8 @@ class ConversionsTestCase(unittest.TestCase):
 
     def test_line_conversion(self):
         d = self.fields.copy()
-        assert formats.line_format.conversion.convert(d) == '2010-10-28T02:15:57Z:INFO:mylog:pants=42'
+        assert formats.line_format.conversion.convert(d) == \
+            '2010-10-28T02:15:57Z:INFO:mylog:pants=42'
 
         del d['pants']
         assert formats.line_format.conversion.convert(d) == '2010-10-28T02:15:57Z:INFO:mylog'
@@ -64,7 +65,8 @@ class FormatTestCase(unittest.TestCase):
         assert my_format.separator == formats.line_format.separator
         assert my_format.traceback_prefix == formats.line_format.traceback_prefix
 
-        # XXX it'd be nice to test the guts of the conversion for equality, but Converters don't support that
+        # XXX it'd be nice to test the guts of the conversion for equality, but
+        # Converters don't support that
         assert my_format.conversion is not formats.line_format.conversion
 
     def test_basic(self):
@@ -87,7 +89,8 @@ class FormatTestCase(unittest.TestCase):
         msg = message.Message(levels.INFO, "I wear {0}\nDo you?", fields, opts, ['pants'], {})
         s = fmt(msg)
 
-        assert s == '2010-10-28T02:15:57Z:INFO:mylog:pants=42:shirt=extra\\nlarge|I wear pants\\nDo you?\n', repr(s)
+        assert s == '2010-10-28T02:15:57Z:INFO:mylog:pants=42:shirt=extra\\nlarge|' \
+            'I wear pants\\nDo you?\n', repr(s)
 
     def test_suppress_newline_false(self):
 
@@ -100,7 +103,8 @@ class FormatTestCase(unittest.TestCase):
         opts['suppress_newlines'] = False
         msg = message.Message(levels.INFO, "I wear {0}\nDo you?", fields, opts, ['pants'], {})
         s = fmt(msg)
-        assert s == '2010-10-28T02:15:57Z:INFO:mylog:pants=42:shirt=extra\nlarge|I wear pants\nDo you?\n', repr(s)
+        assert s == '2010-10-28T02:15:57Z:INFO:mylog:pants=42:shirt=extra\nlarge|' \
+            'I wear pants\nDo you?\n', repr(s)
 
     def test_trace(self):
 
@@ -124,7 +128,8 @@ class FormatTestCase(unittest.TestCase):
 
     def test_trace_fold(self):
 
-        fmt = formats.LineFormat(separator='|', traceback_prefix='\\n', conversion=formats.line_conversion)
+        fmt = formats.LineFormat(separator='|', traceback_prefix='\\n',
+                                 conversion=formats.line_conversion)
 
         opts = message.Message._default_options.copy()
         opts['trace'] = 'error'

--- a/tests/test_globals.py
+++ b/tests/test_globals.py
@@ -1,65 +1,65 @@
 import sys
-if sys.version_info >= (2, 7):
-    import unittest
-else:
-    try: 
-        import unittest2 as unittest
-    except ImportError:
-        raise RuntimeError("unittest2 is required for Python < 2.7")
-import sys
 import os
 import tempfile
 
 import twiggy
+
+if sys.version_info >= (2, 7):
+    import unittest
+else:
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        raise RuntimeError("unittest2 is required for Python < 2.7")
 
 
 class GlobalsTestCase(unittest.TestCase):
 
     def setUp(self):
         twiggy._populate_globals()
-    
+
     def tearDown(self):
         twiggy._del_globals()
-    
+
     def test_populate_globals_twice(self):
-    
+
         with self.assertRaises(RuntimeError):
             twiggy._populate_globals()
-    
+
     def test_globals(self):
         assert isinstance(twiggy.log, twiggy.logger.Logger)
         assert isinstance(twiggy.emitters, dict)
         assert twiggy.emitters is twiggy.log._emitters
-        
+
         assert isinstance(twiggy.internal_log, twiggy.logger.InternalLogger)
         assert twiggy.internal_log._fields['name'] == 'twiggy.internal'
         assert twiggy.internal_log._options['trace'] == 'error'
-        
+
         assert isinstance(twiggy.devel_log, twiggy.logger.InternalLogger)
         assert twiggy.devel_log._fields['name'] == 'twiggy.devel'
         assert isinstance(twiggy.devel_log.output, twiggy.outputs.NullOutput)
-    
+
     def test_add_emitters(self):
-        
-        out = twiggy.outputs.ListOutput(close_atexit = False)
-        
+
+        out = twiggy.outputs.ListOutput(close_atexit=False)
+
         def cleanup(out):
             out.close()
-        
+
         self.addCleanup(cleanup, out)
-        
+
         def myfilt(msg):
             return True
-        
+
         twiggy.add_emitters(('test', twiggy.levels.INFO, myfilt, out))
-        
+
         assert len(twiggy.emitters) == 1
         e = twiggy.emitters['test']
         assert isinstance(e, twiggy.filters.Emitter)
         assert e.min_level == twiggy.levels.INFO
         assert e.filter is myfilt
         assert e._output is out
-        
+
     def test_quick_setup_None(self):
         twiggy.quick_setup(file=None)
         assert len(twiggy.emitters) == 1
@@ -75,14 +75,13 @@ class GlobalsTestCase(unittest.TestCase):
         assert isinstance(e, twiggy.filters.Emitter)
         assert isinstance(e._output, twiggy.outputs.StreamOutput)
         assert e._output.stream is sys.stdout
-    
-        
+
     def test_quick_setup_file(self):
 
         fname = tempfile.mktemp()
         print(fname)
-        
-        @self.addCleanup      
+
+        @self.addCleanup
         def cleanup():
             os.remove(fname)
 
@@ -92,8 +91,3 @@ class GlobalsTestCase(unittest.TestCase):
         assert isinstance(e, twiggy.filters.Emitter)
         assert isinstance(e._output, twiggy.outputs.FileOutput)
         assert os.path.exists(fname)
-
-        
-                
-
-

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,13 +1,7 @@
 from __future__ import print_function
 
+import re
 import sys
-if sys.version_info >= (2, 7):
-    import unittest
-else:
-    try: 
-        import unittest2 as unittest
-    except ImportError:
-        raise RuntimeError("unittest2 is required for Python < 2.7")
 
 from six import StringIO
 
@@ -15,16 +9,25 @@ import twiggy
 
 from . import when
 
+if sys.version_info >= (2, 7):
+    import unittest
+else:
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        raise RuntimeError("unittest2 is required for Python < 2.7")
+
 
 def fake_gmtime():
     return when
+
 
 class IntegrationTestCase(unittest.TestCase):
 
     def setUp(self):
         twiggy._populate_globals()
         twiggy.log._fields['time'] = fake_gmtime
-    
+
     def tearDown(self):
         twiggy._del_globals()
 
@@ -32,21 +35,21 @@ class IntegrationTestCase(unittest.TestCase):
         everything = twiggy.outputs.StreamOutput(stream=StringIO(), format=twiggy.formats.line_format)
         out1 = twiggy.outputs.StreamOutput(stream=StringIO(), format=twiggy.formats.line_format)
         out2 = twiggy.outputs.StreamOutput(stream=StringIO(), format=twiggy.formats.line_format)
-        
+
         twiggy.add_emitters(('*', twiggy.levels.DEBUG, None, everything),
-                           ('first', twiggy.levels.INFO, None, out1),
-                           ('second', twiggy.levels.DEBUG, twiggy.filters.glob_names('second.*'), out2),
-                           ('first-filter', twiggy.levels.DEBUG, ".*pants.*", out1))
-        
+                            ('first', twiggy.levels.INFO, None, out1),
+                            ('second', twiggy.levels.DEBUG, twiggy.filters.glob_names('second.*'), out2),
+                            ('first-filter', twiggy.levels.DEBUG, ".*pants.*", out1))
+
         def something():
             return "something cool"
-        
+
         twiggy.log.debug("oh hi")
         twiggy.log.name("second").info("do you like cheese?")
         twiggy.log.name("second.child").fields(cheese="hate").warning("No")
         twiggy.log.name("first").error("Can you do {0}", something)
         twiggy.log.name("bob").debug("I wear pants")
-        
+
         try:
             raise RuntimeError("Oh Noes!")
         except:
@@ -57,27 +60,27 @@ class IntegrationTestCase(unittest.TestCase):
         print("****************** out 1 **************************")
         print(out1.stream.getvalue(), end=' ')
         print("****************** out 2 **************************")
-        print(out2.stream.getvalue(), end=' ')       
+        print(out2.stream.getvalue(), end=' ')
         print("***************************************************")
-        
 
         # XXX this should really be done with a regex, but I'm feeling lazy
-        assert out1.stream.getvalue().startswith( \
-"""2010-10-28T02:15:57Z:INFO:second|do you like cheese?
+        assert out1.stream.getvalue().startswith(
+            """2010-10-28T02:15:57Z:INFO:second|do you like cheese?
 2010-10-28T02:15:57Z:WARNING:second.child:cheese=hate|No
 2010-10-28T02:15:57Z:ERROR:first|Can you do something cool
 2010-10-28T02:15:57Z:DEBUG:bob|I wear pants
 2010-10-28T02:15:57Z:CRITICAL|Went boom
 TRACE Traceback (most recent call last):
 """)
-#"""TRACE   File "/home/pfein/Projects/python-twiggy/tests/test_integration.py", line 39, in test_integration
-        assert out1.stream.getvalue().endswith( \
-"""TRACE     raise RuntimeError("Oh Noes!")
+        exception_line_re = re.compile(r'TRACE   File'
+                                       ' "/[^"]*/tests/test_integration.py",'
+                                       ' line [0-9]+,')
+        assert exception_line_re.search(out1.stream.getvalue())
+        assert out1.stream.getvalue().endswith(
+            """TRACE     raise RuntimeError("Oh Noes!")
 TRACE RuntimeError: Oh Noes!
 """)
-        
 
         assert out2.stream.getvalue() == \
-"""2010-10-28T02:15:57Z:WARNING:second.child:cheese=hate|No
+            """2010-10-28T02:15:57Z:WARNING:second.child:cheese=hate|No
 """
-

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -32,13 +32,14 @@ class IntegrationTestCase(unittest.TestCase):
         twiggy._del_globals()
 
     def test_integration(self):
-        everything = twiggy.outputs.StreamOutput(stream=StringIO(), format=twiggy.formats.line_format)
+        all_ = twiggy.outputs.StreamOutput(stream=StringIO(), format=twiggy.formats.line_format)
         out1 = twiggy.outputs.StreamOutput(stream=StringIO(), format=twiggy.formats.line_format)
         out2 = twiggy.outputs.StreamOutput(stream=StringIO(), format=twiggy.formats.line_format)
 
-        twiggy.add_emitters(('*', twiggy.levels.DEBUG, None, everything),
+        twiggy.add_emitters(('*', twiggy.levels.DEBUG, None, all_),
                             ('first', twiggy.levels.INFO, None, out1),
-                            ('second', twiggy.levels.DEBUG, twiggy.filters.glob_names('second.*'), out2),
+                            ('second', twiggy.levels.DEBUG,
+                             twiggy.filters.glob_names('second.*'), out2),
                             ('first-filter', twiggy.levels.DEBUG, ".*pants.*", out1))
 
         def something():
@@ -55,8 +56,8 @@ class IntegrationTestCase(unittest.TestCase):
         except:
             twiggy.log.trace().critical("Went boom")
 
-        print("***************** everything **********************")
-        print(everything.stream.getvalue(), end=' ')
+        print("****************** all_ ***************************")
+        print(all_.stream.getvalue(), end=' ')
         print("****************** out 1 **************************")
         print(out1.stream.getvalue(), end=' ')
         print("****************** out 2 **************************")
@@ -72,9 +73,8 @@ class IntegrationTestCase(unittest.TestCase):
 2010-10-28T02:15:57Z:CRITICAL|Went boom
 TRACE Traceback (most recent call last):
 """)
-        exception_line_re = re.compile(r'TRACE   File'
-                                       ' "/[^"]*/tests/test_integration.py",'
-                                       ' line [0-9]+,')
+        exception_line_re = re.compile(r'TRACE   File "/[^"]*/tests/test_integration.py",'
+                                       r' line [0-9]+,')
         assert exception_line_re.search(out1.stream.getvalue())
         assert out1.stream.getvalue().endswith(
             """TRACE     raise RuntimeError("Oh Noes!")

--- a/tests/test_levels.py
+++ b/tests/test_levels.py
@@ -1,14 +1,15 @@
 import sys
+
+from twiggy import levels
+
 if sys.version_info >= (2, 7):
     import unittest
 else:
-    try: 
+    try:
         import unittest2 as unittest
     except ImportError:
         raise RuntimeError("unittest2 is required for Python < 2.7")
-import sys
 
-from twiggy import levels
 
 class LevelTestCase(unittest.TestCase):
 
@@ -76,13 +77,13 @@ class LevelTestCase(unittest.TestCase):
         assert levels.DISABLED != levels.CRITICAL
 
     def test_dict_key(self):
-        d={levels.DEBUG:42}
+        d = {levels.DEBUG: 42}
         assert d[levels.DEBUG] == 42
 
     def test_bogus_not_equals(self):
         assert levels.DEBUG != 1
 
-    @unittest.skipIf(sys.version_info < (3,), "Python 2.x comparisons are insane")
+    @unittest.skipIf(sys.version_info < (3, ), "Python 2.x comparisons are insane")
     def test_bogus_compare(self):
         # XXX is there a comparable test for 2.x?
         with self.assertRaises(TypeError):

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -1,29 +1,32 @@
 import sys
-if sys.version_info >= (2, 7):
-    import unittest
-else:
-    try: 
-        import unittest2 as unittest
-    except ImportError:
-        raise RuntimeError("unittest2 is required for Python < 2.7")
 import threading
 
 from twiggy import lib
 
 from . import when
 
+if sys.version_info >= (2, 7):
+    import unittest
+else:
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        raise RuntimeError("unittest2 is required for Python < 2.7")
+
+
 class ThreadNameTest(unittest.TestCase):
 
     def test_thread_name(self):
         def doit():
             self.name = lib.thread_name()
-        
+
         t = threading.Thread(target=doit, name="Bob")
         t.start()
         t.join()
         assert self.name == "Bob"
 
+
 class IsoTimeTest(unittest.TestCase):
-    
+
     def test_iso_time(self):
-        assert lib.iso8601time(when) == "2010-10-28T02:15:57Z" 
+        assert lib.iso8601time(when) == "2010-10-28T02:15:57Z"

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,45 +1,46 @@
 import re
 import sys
-if sys.version_info >= (2, 7):
-    import unittest
-else:
-    try: 
-        import unittest2 as unittest
-    except ImportError:
-        raise RuntimeError("unittest2 is required for Python < 2.7")
 
 from six import StringIO
 
 import twiggy as _twiggy
 from twiggy import logger, outputs, levels, filters
 
+if sys.version_info >= (2, 7):
+    import unittest
+else:
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        raise RuntimeError("unittest2 is required for Python < 2.7")
+
 
 class LoggerTestBase(object):
     """common tests for loggers"""
+
     def test_fields_dict(self):
-        d={42:42}
+        d = {42: 42}
         log = self.log.fields_dict(d)
         assert log is not self.log
         assert log._fields == d
         assert log._fields is not d
-
         # we could do the same tests on options/min_level as done
         # in test_clone, but that's starting to get redundant
 
     def test_fields(self):
         log = self.log.fields(a=42)
         assert log is not self.log
-        assert log._fields == {'a':42}
+        assert log._fields == {'a': 42}
 
     def test_name(self):
         log = self.log.name('bob')
         assert log is not self.log
-        assert log._fields == {'name':'bob'}
+        assert log._fields == {'name': 'bob'}
 
     def test_options(self):
         log = self.log.options(suppress_newlines=True)
         assert log is not self.log
-        assert log._options['suppress_newlines'] == True
+        assert log._options['suppress_newlines'] is True
 
     def test_bad_options(self):
         with self.assertRaises(ValueError):
@@ -109,10 +110,11 @@ class LoggerTestBase(object):
         log.info('hi')
         assert len(self.messages) == 0
 
+
 class InternalLoggerTest(LoggerTestBase, unittest.TestCase):
 
     def setUp(self):
-        self.output = outputs.ListOutput(close_atexit = False)
+        self.output = outputs.ListOutput(close_atexit=False)
         self.messages = self.output.messages
         self.log = logger.InternalLogger(output=self.output)
 
@@ -122,7 +124,8 @@ class InternalLoggerTest(LoggerTestBase, unittest.TestCase):
     def test_clone(self):
         log = self.log._clone()
         assert log is not self.log
-        assert type(log) is type(self.log)
+        assert isinstance(log, logger.InternalLogger)
+        assert isinstance(self.log, logger.InternalLogger)
         assert log.output is self.output
 
         assert log._fields == self.log._fields
@@ -150,7 +153,7 @@ class InternalLoggerTest(LoggerTestBase, unittest.TestCase):
 
         assert "BOOM" in sio.getvalue()
         assert "Offending message: None" in sio.getvalue()
-        assert "Error in twiggy internal log! Something is serioulsy broken." in sio.getvalue()
+        assert "Error in twiggy internal log! Something is seriously broken." in sio.getvalue()
         assert "Traceback" in sio.getvalue()
 
     def test_trap_output(self):
@@ -159,7 +162,7 @@ class InternalLoggerTest(LoggerTestBase, unittest.TestCase):
             def _write(self, x):
                 raise RuntimeError("BORK")
 
-        out = BorkedOutput(close_atexit = False)
+        out = BorkedOutput(close_atexit=False)
 
         sio = StringIO()
 
@@ -173,29 +176,29 @@ class InternalLoggerTest(LoggerTestBase, unittest.TestCase):
         sys.stderr = sio
         self.log.output = out
 
-
         self.log.fields().info('hi')
 
         assert "BORK" in sio.getvalue()
         assert "Offending message: <twiggy.message.Message object" in sio.getvalue()
-        assert "Error in twiggy internal log! Something is serioulsy broken." in sio.getvalue()
+        assert "Error in twiggy internal log! Something is seriously broken." in sio.getvalue()
         assert "Traceback" in sio.getvalue()
+
 
 class LoggerTestCase(LoggerTestBase, unittest.TestCase):
 
     def setUp(self):
         self.log = logger.Logger()
         self.emitters = self.log._emitters
-        self.output = outputs.ListOutput(close_atexit = False)
+        self.output = outputs.ListOutput(close_atexit=False)
         self.emitters['*'] = filters.Emitter(levels.DEBUG, None, self.output)
         self.messages = self.output.messages
 
     def tearDown(self):
         self.output.close()
         self.emitters.clear()
-    
+
     def test_struct_dict(self):
-        d={42:42}
+        d = {42: 42}
         self.log.struct_dict(d)
         assert len(self.messages) == 1
         m = self.messages.pop()
@@ -203,7 +206,6 @@ class LoggerTestCase(LoggerTestBase, unittest.TestCase):
         assert m.fields is not d
         assert m.text == ""
         assert m.level == levels.INFO
-
         # we could do the same tests on options/min_level as done
         # in test_clone, but that's starting to get redundant
 
@@ -211,51 +213,50 @@ class LoggerTestCase(LoggerTestBase, unittest.TestCase):
         self.log.struct(x=42)
         assert len(self.messages) == 1
         m = self.messages.pop()
-        self.assertDictContainsSubset({'x':42}, m.fields)
+        self.assertDictContainsSubset({'x': 42}, m.fields)
         assert m.text == ""
         assert m.level == levels.INFO
-    
+
     def test_no_emitters(self):
         self.emitters.clear()
         self.log.debug('hi')
         assert len(self.messages) == 0
-    
+
     def test_min_level_emitters(self):
         self.emitters['*'].min_level = levels.INFO
         self.log.debug('hi')
         assert len(self.messages) == 0
-    
+
     def test_filter_emitters(self):
         self.emitters['*'].filter = 'pants'
         self.log.debug('hi')
         assert len(self.messages) == 0
-    
+
     def test_logger_filter(self):
         self.log.filter = lambda fmt_spec: 'pants' in fmt_spec
         self.log.debug('hi')
         assert len(self.messages) == 0
-        
+
         self.log.filter = lambda fmt_spec: 'hi' in fmt_spec
         self.log.debug('hi')
         assert len(self.messages) == 1
         m = self.messages.pop()
         assert m.text == 'hi'
 
+
 class LoggerTrapTestCase(unittest.TestCase):
 
-    
     def setUp(self):
-        self.internal_output = outputs.ListOutput(close_atexit = False)
+        self.internal_output = outputs.ListOutput(close_atexit=False)
         self.internal_messages = self.internal_output.messages
         _twiggy._populate_globals()
         _twiggy.internal_log.output = self.internal_output
 
         self.log = logger.Logger()
         self.emitters = self.log._emitters
-        self.output = outputs.ListOutput(close_atexit = False)
+        self.output = outputs.ListOutput(close_atexit=False)
         self.emitters['everything'] = filters.Emitter(levels.DEBUG, None, self.output)
         self.messages = self.output.messages
-
 
     def tearDown(self):
         self.internal_output.close()
@@ -266,65 +267,65 @@ class LoggerTrapTestCase(unittest.TestCase):
 
     def test_bad_logger_filter(self):
         def bad_filter(fmt_spec):
-            raise RuntimeError("THUNK")    
-    
+            raise RuntimeError("THUNK")
+
         self.log.filter = bad_filter
-        
+
         # a bad filter doesn't stop emitting
         self.log.debug('hi')
         assert len(self.messages) == 1
         m = self.messages.pop()
         assert m.text == 'hi'
-        
+
         assert len(self.internal_messages) == 1
         m = self.internal_messages.pop()
-        
+
         print(m.text)
         print(m.traceback)
         print(_twiggy.internal_log._options)
-        
+
         assert m.level == levels.INFO
         assert m.name == 'twiggy.internal'
         assert "Traceback" in m.traceback
         assert "THUNK" in m.traceback
         assert "Error in Logger filtering" in m.text
         assert re.search("<function .*bad_filter", m.text)
-                
+
     def test_trap_bad_msg(self):
         def go_boom():
             raise RuntimeError("BOOM")
 
         self.log.fields(func=go_boom).info('hi')
         assert len(self.messages) == 0
-        
+
         assert len(self.internal_messages) == 1
         m = self.internal_messages.pop()
-        
+
         print(m.text)
         print(m.traceback)
         print(_twiggy.internal_log._options)
-        
+
         assert m.level == levels.INFO
         assert m.name == 'twiggy.internal'
         assert "Traceback" in m.traceback
         assert "BOOM" in m.traceback
         assert "Error formatting message" in m.text
         assert re.search("<function .*go_boom", m.text)
-    
+
     def test_trap_output(self):
         class BorkedOutput(outputs.ListOutput):
 
             def _write(self, x):
                 raise RuntimeError("BORK")
 
-        out = BorkedOutput(close_atexit = False)
+        out = BorkedOutput(close_atexit=False)
 
         def cleanup(output):
             try:
                 del self.emitters['before']
             except KeyError:
                 pass
-                
+
             out.close()
 
         self.addCleanup(cleanup, out)
@@ -336,7 +337,7 @@ class LoggerTrapTestCase(unittest.TestCase):
         assert len(self.messages) == 1
         m = self.messages.pop()
         assert m.text == "hi"
-        
+
         assert len(self.internal_messages) == 1
         m = self.internal_messages.pop()
 
@@ -349,18 +350,17 @@ class LoggerTrapTestCase(unittest.TestCase):
             m.text)
         assert "Traceback" in m.traceback
         assert "BORK" in m.traceback
-        
-        
+
     def test_trap_filter(self):
 
-        out = outputs.ListOutput(close_atexit = False)
+        out = outputs.ListOutput(close_atexit=False)
 
         def cleanup(output):
             try:
                 del self.emitters['before']
             except KeyError:
                 pass
-                
+
             out.close()
 
         self.addCleanup(cleanup, out)
@@ -380,9 +380,9 @@ class LoggerTrapTestCase(unittest.TestCase):
         assert len(self.messages) == 1
         m2 = self.messages.pop()
         assert m2.text == "hi"
-        
+
         assert m1 is m2
-        
+
         assert len(self.internal_messages) == 1
         m = self.internal_messages.pop()
 
@@ -394,6 +394,3 @@ class LoggerTrapTestCase(unittest.TestCase):
         assert re.search("<function .*go_boom", m.text)
         assert "Traceback" in m.traceback
         assert "BOOM" in m.traceback
-        
-        
-

--- a/tests/test_logging_compat.py
+++ b/tests/test_logging_compat.py
@@ -1,24 +1,27 @@
 import sys
 from unittest import TestCase
 
+
 def setUpModule():
     from twiggy import _populate_globals
     _populate_globals()
+
 
 def tearDownModule():
     from twiggy import _del_globals
     _del_globals()
 
+
 class HijackTest(TestCase):
 
     def compare_modules(self, m1, m2):
         self.failUnlessEqual(m1.__name__, m2.__name__)
-        
+
     def verify_orig(self):
         import logging
         from twiggy.logging_compat import orig_logging
         self.compare_modules(logging, orig_logging)
-        
+
     def verify_comp(self):
         import logging
         from twiggy import logging_compat
@@ -39,12 +42,13 @@ class HijackTest(TestCase):
         restore()
         self.verify_orig()
 
+
 class TestGetLogger(TestCase):
-    
+
     def test_name(self):
         from twiggy.logging_compat import getLogger
         self.failUnlessEqual(getLogger("spam")._logger._fields["name"], "spam")
-    
+
     def test_root(self):
         from twiggy.logging_compat import getLogger, root
         self.failUnlessEqual(getLogger(), root)
@@ -53,9 +57,10 @@ class TestGetLogger(TestCase):
         from twiggy.logging_compat import getLogger
         eggs = getLogger("eggs")
         self.failUnless(getLogger("eggs") is eggs)
-        
+
+
 class TestFakeLogger(TestCase):
-    
+
     def setUp(self):
         from twiggy import add_emitters
         from twiggy.logging_compat import getLogger, DEBUG
@@ -71,13 +76,13 @@ class TestFakeLogger(TestCase):
         for level in [INFO, ERROR]:
             self.logger.setLevel(level)
             self.failUnlessEqual(self.logger.level, level)
-            
+
     def test_percent(self):
         self.failUnlessEqual(self.logger._logger._options["style"], "percent")
 
     def test_exception(self):
         try:
-            1/0
+            1 / 0
         except:
             self.logger.exception("spam")
         self.failUnless("ZeroDivisionError" in self.messages[0].traceback)
@@ -95,11 +100,11 @@ class TestFakeLogger(TestCase):
 
     def test_log_exc_info(self):
         try:
-            1/0
+            1 / 0
         except:
             self.logger.error("exception", exc_info=True)
         self.failUnless("ZeroDivisionError" in self.messages[0].traceback)
-        
+
     def test_basicConfig(self):
         from twiggy.logging_compat import basicConfig
         self.failUnlessRaises(RuntimeError, basicConfig)
@@ -113,9 +118,10 @@ class TestFakeLogger(TestCase):
 
     def test_log_bad_level(self):
         self.failUnlessRaises(ValueError, self.logger.log, "illegal level", "eggs")
-        
+
+
 class TestLoggingBridge(TestCase):
-    
+
     def test_format(self):
         from twiggy import add_emitters
         from twiggy import log
@@ -127,7 +133,7 @@ class TestLoggingBridge(TestCase):
         add_emitters(("spam", DEBUG, None, list_output))
         logger.error("eggs")
         self.failUnlessEqual(messages[0], ('|eggs\n', ERROR, 'spam'))
-        
+
     def test_sanity(self):
         from twiggy import add_emitters, log
         from twiggy.logging_compat import LoggingBridgeOutput, DEBUG

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,24 +1,25 @@
 import sys
-if sys.version_info >= (2, 7):
-    import unittest
-else:
-    try: 
-        import unittest2 as unittest
-    except ImportError:
-        raise RuntimeError("unittest2 is required for Python < 2.7")
-import sys
 
 import twiggy.levels
 from twiggy.message import Message
 
 from . import make_mesg
 
+if sys.version_info >= (2, 7):
+    import unittest
+else:
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        raise RuntimeError("unittest2 is required for Python < 2.7")
+
+
 class MessageTestCase(unittest.TestCase):
 
     def test_basic(self):
         m = make_mesg()
 
-        assert m.fields == {'shirt':42, 'name': 'jose', 'level':twiggy.levels.DEBUG}
+        assert m.fields == {'shirt': 42, 'name': 'jose', 'level': twiggy.levels.DEBUG}
         assert m.traceback is None
 
         assert m.text == "Hello Mister Funnypants"
@@ -40,7 +41,7 @@ class MessageTestCase(unittest.TestCase):
                     {},
                     opts,
                     args=["Mister"],
-                    kwargs={'who':"Funnypants\nand shirt"},
+                    kwargs={'who': "Funnypants\nand shirt"},
                     )
 
         assert m.text == '''Hello Mister Funnypants\nand shirt'''
@@ -54,23 +55,23 @@ class MessageTestCase(unittest.TestCase):
                     {},
                     opts,
                     args=["Mister"],
-                    kwargs={'who':"Funnypants\nand shirt"},
+                    kwargs={'who': "Funnypants\nand shirt"},
                     )
 
         assert m.text == \
-'''Hello Mister Funnypants
+            '''Hello Mister Funnypants
 and shirt'''
 
     def test_no_args(self):
         m = Message(twiggy.levels.DEBUG,
                     "Hello {who}",
-                    {'shirt':42, 'name': 'jose'},
+                    {'shirt': 42, 'name': 'jose'},
                     Message._default_options,
                     args=(),
-                    kwargs={'who':"Funnypants"},
+                    kwargs={'who': "Funnypants"},
                     )
 
-        assert m.fields == {'shirt':42, 'name': 'jose', 'level':twiggy.levels.DEBUG}
+        assert m.fields == {'shirt': 42, 'name': 'jose', 'level': twiggy.levels.DEBUG}
         assert m.traceback is None
 
         assert m.text == "Hello Funnypants"
@@ -78,13 +79,13 @@ and shirt'''
     def test_no_kwargs(self):
         m = Message(twiggy.levels.DEBUG,
                     "Hello {0}",
-                    {'shirt':42, 'name': 'jose'},
+                    {'shirt': 42, 'name': 'jose'},
                     Message._default_options,
                     args=['Mister'],
                     kwargs={}
                     )
 
-        assert m.fields == {'shirt':42, 'name': 'jose', 'level':twiggy.levels.DEBUG}
+        assert m.fields == {'shirt': 42, 'name': 'jose', 'level': twiggy.levels.DEBUG}
         assert m.traceback is None
 
         assert m.text == "Hello Mister"
@@ -92,13 +93,13 @@ and shirt'''
     def test_no_args_no_kwargs(self):
         m = Message(twiggy.levels.DEBUG,
                     "Hello",
-                    {'shirt':42, 'name': 'jose'},
+                    {'shirt': 42, 'name': 'jose'},
                     Message._default_options,
                     (),
                     {}
                     )
 
-        assert m.fields == {'shirt':42, 'name': 'jose', 'level':twiggy.levels.DEBUG}
+        assert m.fields == {'shirt': 42, 'name': 'jose', 'level': twiggy.levels.DEBUG}
         assert m.traceback is None
 
         assert m.text == "Hello"
@@ -113,7 +114,7 @@ and shirt'''
                     {},
                     opts,
                     args=["Mister"],
-                    kwargs={'who':"Funnypants\nand shirt"},
+                    kwargs={'who': "Funnypants\nand shirt"},
                     )
 
     def test_braces_alias(self):
@@ -122,13 +123,13 @@ and shirt'''
 
         m = Message(twiggy.levels.DEBUG,
                     "Hello {who}",
-                    {'shirt':42, 'name': 'jose'},
+                    {'shirt': 42, 'name': 'jose'},
                     opts,
                     args=(),
-                    kwargs={'who':"Funnypants"},
+                    kwargs={'who': "Funnypants"},
                     )
 
-        assert m.fields == {'shirt':42, 'name': 'jose', 'level':twiggy.levels.DEBUG}
+        assert m.fields == {'shirt': 42, 'name': 'jose', 'level': twiggy.levels.DEBUG}
         assert m.traceback is None
 
         assert m.text == "Hello Funnypants"
@@ -142,7 +143,7 @@ and shirt'''
                     {},
                     opts,
                     args=[],
-                    kwargs={'who':"Funnypants"},
+                    kwargs={'who': "Funnypants"},
                     )
 
         assert m.text == "Hello Funnypants"
@@ -156,7 +157,7 @@ and shirt'''
                     {},
                     opts,
                     args=[],
-                    kwargs={'who':"Funnypants"},
+                    kwargs={'who': "Funnypants"},
                     )
 
         assert m.text == "Hello Funnypants"
@@ -167,12 +168,12 @@ and shirt'''
 
         with self.assertRaises(ValueError):
             Message(twiggy.levels.DEBUG,
-                        "Hello $who",
-                        {},
-                        opts,
-                        args=[42],
-                        kwargs={'who':"Funnypants"},
-                        )
+                    "Hello $who",
+                    {},
+                    opts,
+                    args=[42],
+                    kwargs={'who': "Funnypants"},
+                    )
 
     def test_percent_style_args(self):
         opts = Message._default_options.copy()
@@ -197,7 +198,7 @@ and shirt'''
                     {},
                     opts,
                     args=[],
-                    kwargs={'who':"Funnypants"},
+                    kwargs={'who': "Funnypants"},
                     )
 
         assert m.text == "Hello Funnypants"
@@ -208,12 +209,12 @@ and shirt'''
 
         with self.assertRaises(ValueError):
             Message(twiggy.levels.DEBUG,
-                        "Hello %s %(who)s",
-                        {},
-                        opts,
-                        args=["Mister"],
-                        kwargs={'who':"Funnypants\nand shirt"},
-                        )
+                    "Hello %s %(who)s",
+                    {},
+                    opts,
+                    args=["Mister"],
+                    kwargs={'who': "Funnypants\nand shirt"},
+                    )
 
     def test_percent_alias(self):
         opts = Message._default_options.copy()
@@ -235,27 +236,26 @@ and shirt'''
                     {'shirt': lambda: 42, 'name': 'jose'},
                     Message._default_options,
                     args=[lambda: "Mister"],
-                    kwargs={'who':lambda: "Funnypants"},
+                    kwargs={'who': lambda: "Funnypants"},
                     )
 
-        assert m.fields == {'shirt':42, 'name': 'jose', 'level':twiggy.levels.DEBUG}
+        assert m.fields == {'shirt': 42, 'name': 'jose', 'level': twiggy.levels.DEBUG}
         assert m.traceback is None
 
         assert m.text == "Hello Mister Funnypants"
 
     def test_empty_format_spec(self):
         m = Message(twiggy.levels.DEBUG,
-            '',
-            {'shirt': lambda: 42, 'name': 'jose'},
-            Message._default_options,
-            args=[lambda: "Mister"],
-            kwargs={'who':lambda: "Funnypants"},
-            )
+                    '',
+                    {'shirt': lambda: 42, 'name': 'jose'},
+                    Message._default_options,
+                    args=[lambda: "Mister"],
+                    kwargs={'who': lambda: "Funnypants"},
+                    )
 
         assert m.text == ''
         assert m.name == 'jose'
         assert m.fields['shirt'] == 42
-
 
     def test_bad_trace(self):
         opts = Message._default_options.copy()
@@ -263,43 +263,41 @@ and shirt'''
 
         with self.assertRaises(ValueError):
             Message(twiggy.levels.DEBUG,
-                "Hello {0} {who}",
-                {'shirt': lambda: 42, 'name': 'jose'},
-                opts,
-                args=[lambda: "Mister"],
-                kwargs={'who':lambda: "Funnypants"},
-                )
+                    "Hello {0} {who}",
+                    {'shirt': lambda: 42, 'name': 'jose'},
+                    opts,
+                    args=[lambda: "Mister"],
+                    kwargs={'who': lambda: "Funnypants"},
+                    )
 
     def test_trace_error_without_error(self):
         opts = Message._default_options.copy()
         opts['trace'] = 'error'
 
         m = Message(twiggy.levels.DEBUG,
-            "Hello {0} {who}",
-            {'shirt': lambda: 42, 'name': 'jose'},
-            opts,
-            args=[lambda: "Mister"],
-            kwargs={'who':lambda: "Funnypants"},
-            )
+                    "Hello {0} {who}",
+                    {'shirt': lambda: 42, 'name': 'jose'},
+                    opts,
+                    args=[lambda: "Mister"],
+                    kwargs={'who': lambda: "Funnypants"},
+                    )
 
         assert m.traceback is None
-
 
     def test_trace_error_with_error(self):
         opts = Message._default_options.copy()
         opts['trace'] = 'error'
 
-
         try:
-            1/0
+            1 / 0
         except ZeroDivisionError:
             m = Message(twiggy.levels.DEBUG,
-                "Hello {0} {who}",
-                {'shirt': lambda: 42, 'name': 'jose'},
-                opts,
-                args=[lambda: "Mister"],
-                kwargs={'who':lambda: "Funnypants"},
-                )
+                        "Hello {0} {who}",
+                        {'shirt': lambda: 42, 'name': 'jose'},
+                        opts,
+                        args=[lambda: "Mister"],
+                        kwargs={'who': lambda: "Funnypants"},
+                        )
 
         assert m.traceback.startswith('Traceback (most recent call last):')
         assert 'ZeroDivisionError:' in m.traceback
@@ -308,16 +306,16 @@ and shirt'''
         opts = Message._default_options.copy()
 
         try:
-            1/0
+            1 / 0
         except ZeroDivisionError:
             opts['trace'] = sys.exc_info()
             m = Message(twiggy.levels.DEBUG,
-                "Hello {0} {who}",
-                {'shirt': lambda: 42, 'name': 'jose'},
-                opts,
-                args=[lambda: "Mister"],
-                kwargs={'who':lambda: "Funnypants"},
-                )
+                        "Hello {0} {who}",
+                        {'shirt': lambda: 42, 'name': 'jose'},
+                        opts,
+                        args=[lambda: "Mister"],
+                        kwargs={'who': lambda: "Funnypants"},
+                        )
 
         assert m.traceback.startswith('Traceback (most recent call last):')
         assert 'ZeroDivisionError:' in m.traceback

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -1,13 +1,6 @@
 import os
 import sys
 import tempfile
-if sys.version_info >= (2, 7):
-    import unittest
-else:
-    try: 
-        import unittest2 as unittest
-    except ImportError:
-        raise RuntimeError("unittest2 is required for Python < 2.7")
 
 from six import StringIO
 
@@ -15,37 +8,46 @@ from twiggy import outputs, formats
 
 from . import make_mesg, when
 
+if sys.version_info >= (2, 7):
+    import unittest
+else:
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        raise RuntimeError("unittest2 is required for Python < 2.7")
+
 
 m = make_mesg()
 
 # just stuff time in fields so we can use an existing format object
-m.fields['time']=when
+m.fields['time'] = when
+
 
 # XXX I can't think of a decent way to test Output/AsyncOutput on their own...
-
 class UnlockedFileOutput(outputs.FileOutput):
 
     use_locks = False
+
 
 class FileOutputTestCase(unittest.TestCase):
 
     def setUp(self):
         self.fname = tempfile.mktemp()
-    
+
     def tearDown(self):
         try:
             os.remove(self.fname)
         except:
             pass
-                
+
         del self.fname
-    
+
     def make_output(self, msg_buffer, locked):
         cls = outputs.FileOutput if locked else UnlockedFileOutput
-        
-        return cls(name = self.fname, format = formats.shell_format, buffering = 1,
-                   msg_buffer = msg_buffer, close_atexit=False)
-                                         
+
+        return cls(name=self.fname, format=formats.shell_format, buffering=1,
+                   msg_buffer=msg_buffer, close_atexit=False)
+
     def test_sync(self):
         o = self.make_output(0, True)
         o.output(m)
@@ -74,14 +76,16 @@ class FileOutputTestCase(unittest.TestCase):
         s = open(self.fname, 'r').read()
         assert s == "DEBUG:jose:shirt=42|Hello Mister Funnypants\n"
 
+
 class StreamOutputTest(unittest.TestCase):
-    
+
     def test_stream_output(self):
         sio = StringIO()
         o = outputs.StreamOutput(formats.shell_format, sio)
         o.output(m)
         o.close()
         assert sio.getvalue() == "DEBUG:jose:shirt=42|Hello Mister Funnypants\n"
+
 
 class ListOutputTest(unittest.TestCase):
 
@@ -90,10 +94,10 @@ class ListOutputTest(unittest.TestCase):
         o.output(m)
         assert len(o.messages) == 1
         assert o.messages[0] is m
-        
+
         m2 = make_mesg()
         m2.fields['time'] = when
-        
+
         o.output(m2)
         assert o.messages[1] is m2
         o.close()

--- a/tox.ini
+++ b/tox.ini
@@ -16,29 +16,14 @@ deps = sphinx
 changedir = doc
 commands = sphinx-build . _build/html
 
-# Run /bin/true last so that we get logs of things to fix but don't fail the build (yet)
 [testenv:py3flake8]
 basepython = python3.6
 commands =
     pip install flake8
-    sh -c "flake8 twiggy/ tests/ || :"
+    flake8 twiggy/ tests/
 
 [testenv:py2flake8]
 basepython = python2.7
 commands =
     pip install flake8
-    sh -c "flake8 twiggy/ tests/ || :"
-
-# Run pyflakes separate from flake8 for now as we should fix these quickly but
-# pep8 might take longer
-[testenv:py3pyflakes]
-basepython = python3.6
-commands =
-    pip install pyflakes
-    pyflakes twiggy/ tests/
-
-[testenv:py2pyflakes]
-basepython = python2.7
-commands =
-    pip install pyflakes
-    pyflakes twiggy/ tests/
+    flake8 twiggy/ tests/

--- a/twiggy/__init__.py
+++ b/twiggy/__init__.py
@@ -1,4 +1,3 @@
-__all__=['log', 'emitters', 'add_emitters', 'addEmitters', 'devel_log', 'filters', 'formats', 'outputs', 'levels', 'quick_setup', 'quickSetup']
 import time
 import warnings
 import sys
@@ -11,7 +10,10 @@ from . import outputs
 from . import levels
 
 
-## globals creation is wrapped in a function so that we can do sane testing
+__all__ = ['log', 'emitters', 'add_emitters', 'addEmitters', 'devel_log', 'filters', 'formats', 'outputs', 'levels', 'quick_setup', 'quickSetup']
+
+
+# globals creation is wrapped in a function so that we can do sane testing
 def _populate_globals():
     global __fields, log, emitters, __internal_format, __internal_output, internal_log, devel_log
 
@@ -22,28 +24,31 @@ def _populate_globals():
     else:
         raise RuntimeError("Attempted to populate globals twice")
 
-    ## a useful default fields
-    __fields = {'time':time.gmtime}
+    # a useful default fields
+    __fields = {'time': time.gmtime}
 
     log = logger.Logger(__fields)
 
     emitters = log._emitters
 
-    __internal_format = formats.LineFormat(conversion = formats.line_conversion)
+    __internal_format = formats.LineFormat(conversion=formats.line_conversion)
     __internal_output = outputs.StreamOutput(format=__internal_format, stream=sys.stderr)
 
-    internal_log = logger.InternalLogger(fields = __fields, output=__internal_output).name('twiggy.internal').trace('error')
+    internal_log = logger.InternalLogger(fields=__fields, output=__internal_output).name('twiggy.internal').trace('error')
 
-    devel_log = logger.InternalLogger(fields = __fields, output = outputs.NullOutput()).name('twiggy.devel')
+    devel_log = logger.InternalLogger(fields=__fields, output=outputs.NullOutput()).name('twiggy.devel')
+
 
 def _del_globals():
     global __fields, log, emitters, __internal_format, __internal_output, internal_log, devel_log
     del __fields, log, emitters, __internal_format, __internal_output, internal_log, devel_log
 
-if 'TWIGGY_UNDER_TEST' not in os.environ: # pragma: no cover
+
+if 'TWIGGY_UNDER_TEST' not in os.environ:  # pragma: no cover
     _populate_globals()
 
-def quick_setup(min_level=levels.DEBUG, file = None, msg_buffer = 0):
+
+def quick_setup(min_level=levels.DEBUG, file=None, msg_buffer=0):
     """Quickly set up `emitters`.
 
     :arg `.LogLevel` min_level: lowest message level to cause output
@@ -61,11 +66,13 @@ def quick_setup(min_level=levels.DEBUG, file = None, msg_buffer = 0):
 
     emitters['*'] = filters.Emitter(min_level, True, output)
 
+
 def quickSetup(*args, **kwargs):
     warnings.warn(
         "twiggy.quickSetup is deprecated in favor of twiggy.quick_setup",
         DeprecationWarning, stacklevel=2)
     return quick_setup(*args, **kwargs)
+
 
 def add_emitters(*tuples):
     """Add multiple emitters.
@@ -73,6 +80,7 @@ def add_emitters(*tuples):
     """
     for name, min_level, filter, output in tuples:
         emitters[name] = filters.Emitter(min_level, filter, output)
+
 
 def addEmitters(*args, **kwargs):
     warnings.warn(

--- a/twiggy/__init__.py
+++ b/twiggy/__init__.py
@@ -10,7 +10,8 @@ from . import outputs
 from . import levels
 
 
-__all__ = ['log', 'emitters', 'add_emitters', 'addEmitters', 'devel_log', 'filters', 'formats', 'outputs', 'levels', 'quick_setup', 'quickSetup']
+__all__ = ['log', 'emitters', 'add_emitters', 'addEmitters', 'devel_log', 'filters', 'formats',
+           'outputs', 'levels', 'quick_setup', 'quickSetup']
 
 
 # globals creation is wrapped in a function so that we can do sane testing
@@ -34,9 +35,11 @@ def _populate_globals():
     __internal_format = formats.LineFormat(conversion=formats.line_conversion)
     __internal_output = outputs.StreamOutput(format=__internal_format, stream=sys.stderr)
 
-    internal_log = logger.InternalLogger(fields=__fields, output=__internal_output).name('twiggy.internal').trace('error')
+    internal_log = logger.InternalLogger(fields=__fields, output=__internal_output
+                                         ).name('twiggy.internal').trace('error')
 
-    devel_log = logger.InternalLogger(fields=__fields, output=outputs.NullOutput()).name('twiggy.devel')
+    devel_log = logger.InternalLogger(fields=__fields, output=outputs.NullOutput()
+                                      ).name('twiggy.devel')
 
 
 def _del_globals():
@@ -52,7 +55,8 @@ def quick_setup(min_level=levels.DEBUG, file=None, msg_buffer=0):
     """Quickly set up `emitters`.
 
     :arg `.LogLevel` min_level: lowest message level to cause output
-    :arg string file: filename to log to, or ``sys.stdout``, or ``sys.stderr``. ``None`` means standard error.
+    :arg string file: filename to log to, or ``sys.stdout``, or ``sys.stderr``.  ``None`` means
+        standard error.
     :arg int msg_buffer: number of messages to buffer, see `.outputs.AsyncOutput.msg_buffer`
     """
 
@@ -62,7 +66,8 @@ def quick_setup(min_level=levels.DEBUG, file=None, msg_buffer=0):
     if file is sys.stderr or file is sys.stdout:
         output = outputs.StreamOutput(formats.shell_format, stream=file)
     else:
-        output = outputs.FileOutput(file, format=formats.line_format, msg_buffer=msg_buffer, mode='a')
+        output = outputs.FileOutput(file, format=formats.line_format,
+                                    msg_buffer=msg_buffer, mode='a')
 
     emitters['*'] = filters.Emitter(min_level, True, output)
 
@@ -75,8 +80,11 @@ def quickSetup(*args, **kwargs):
 
 
 def add_emitters(*tuples):
-    """Add multiple emitters.
-    ``tuples`` should be ``(name_of_emitter, min_level, filter, output)``. The last three are passed to :class:`.Emitter`.
+    """
+    Add multiple emitters
+
+    ``tuples`` should be ``(name_of_emitter, min_level, filter, output)``.
+    The last three are passed to :class:`.Emitter`.
     """
     for name, min_level, filter, output in tuples:
         emitters[name] = filters.Emitter(min_level, filter, output)

--- a/twiggy/features/procinfo.py
+++ b/twiggy/features/procinfo.py
@@ -4,13 +4,12 @@ from ..lib import thread_name
 import platform
 import os
 
+
 def procinfo(self):
     """Adds the following fields:
 
     :hostname: current hostname
-    :pid: current process id 
+    :pid: current process id
     :thread: current thread name
     """
     return self.fields(hostname=platform.node, pid=os.getpid, thread=thread_name)
-
-

--- a/twiggy/features/socket.py
+++ b/twiggy/features/socket.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import
 
 import socket as _socket
 
-#XXX these need robustification for non-TCP sockets, etc.
 
+# XXX these need robustification for non-TCP sockets, etc.
 def socket(self, s):
     """Adds the following fields:
 
@@ -18,6 +18,7 @@ def socket(self, s):
     ip_addr, port = s.getpeername()
     host, service = _socket.getnameinfo((ip_addr, port), 0)
     return self.fields(ip_addr=ip_addr, port=port, host=host, service=service)
+
 
 def socket_minimal(self, s):
     """Like `.socket`, but only log ``ip_addr`` and ``port``"""

--- a/twiggy/filters.py
+++ b/twiggy/filters.py
@@ -5,8 +5,7 @@ from six import string_types
 
 from . import levels
 
-
-__re_type = type(re.compile('foo')) # XXX is there a canonical place for this?
+__re_type = type(re.compile('foo'))  # XXX is there a canonical place for this?
 
 
 def msg_filter(x):
@@ -20,7 +19,7 @@ def msg_filter(x):
         return regex_wrapper(re.compile(x))
     elif isinstance(x, __re_type):
         return regex_wrapper(x)
-    elif callable(x): # XXX test w/ inspect.getargs here?
+    elif callable(x):  # XXX test w/ inspect.getargs here?
         return x
     elif isinstance(x, (list, tuple)):
         return list_wrapper(x)
@@ -28,14 +27,18 @@ def msg_filter(x):
         # XXX a dict could be used to filter on fields (w/ callables?)
         raise ValueError("Unknown filter: {0!r}".format(x))
 
+
 def list_wrapper(l):
     filts = [msg_filter(i) for i in l]
+
     def wrapped(msg):
         return all(f(msg) for f in filts)
     return wrapped
 
+
 def regex_wrapper(regexp):
     assert isinstance(regexp, __re_type)
+
     def wrapped(msg):
         return regexp.match(msg.text) is not None
     return wrapped
@@ -44,20 +47,22 @@ def regex_wrapper(regexp):
 def names(*names):
     """returns a filter, which gives True if the messsage's name equals any of those provided"""
     names_set = set(names)
+
     def set_names_filter(msg):
         return msg.name in names_set
     set_names_filter.names = names
     return set_names_filter
 
+
 def glob_names(*names):
     """returns a filter, which gives True if the messsage's name globs those provided."""
     # copied from fnmatch.fnmatchcase - for speed
     patterns = [re.compile(fnmatch.translate(pat)) for pat in names]
+
     def glob_names_filter(msg):
         return any(pat.match(msg.name) is not None for pat in patterns)
     glob_names_filter.names = names
     return glob_names_filter
-
 
 
 class Emitter(object):

--- a/twiggy/filters.py
+++ b/twiggy/filters.py
@@ -45,7 +45,14 @@ def regex_wrapper(regexp):
 
 
 def names(*names):
-    """returns a filter, which gives True if the messsage's name equals any of those provided"""
+    """
+    Returns a filter which matches message names against exact strings
+
+    :args names: Any number of arguments are accepted.  Each one should be a string which can
+        exactly match a message's name.
+    :returns: A filter function.  The function returns True if the msg name is the same as one of
+        the names provided here.
+    """
     names_set = set(names)
 
     def set_names_filter(msg):
@@ -55,7 +62,14 @@ def names(*names):
 
 
 def glob_names(*names):
-    """returns a filter, which gives True if the messsage's name globs those provided."""
+    """
+    Return a filter which matches message names based on a list of globs
+
+    :args names: Any number of arguments are accepted.  Each one should be a glob pattern which can
+        match a message's name.
+    :returns: A filter function.  The function returns True if the msg name matches one of the glob
+        patterns provided here.
+    """
     # copied from fnmatch.fnmatchcase - for speed
     patterns = [re.compile(fnmatch.translate(pat)) for pat in names]
 

--- a/twiggy/formats.py
+++ b/twiggy/formats.py
@@ -18,6 +18,7 @@ line_conversion.generic_value = str
 line_conversion.generic_item = "{0}={1}".format
 line_conversion.aggregate = ':'.join
 
+
 class LineFormat(object):
     """format a message for text-oriented output. Returns a string."""
 
@@ -34,7 +35,7 @@ class LineFormat(object):
         fields = self.format_fields(msg)
         text = self.format_text(msg)
         trace = self.format_traceback(msg)
-        return "{fields}{self.separator}{text}{trace}\n".format(**locals()) # XXX gross?
+        return "{fields}{self.separator}{text}{trace}\n".format(**locals())  # XXX gross?
 
     def format_text(self, msg):
         """format the text part of a message"""
@@ -60,7 +61,10 @@ class LineFormat(object):
             fields_text = fields_text.replace('\n', '\\n')
         return fields_text
 
-## some useful default objects
+
+#
+# some useful default objects
+#
 
 #: a decent-looking format for line-oriented output
 line_format = LineFormat(conversion=line_conversion)

--- a/twiggy/levels.py
+++ b/twiggy/levels.py
@@ -1,5 +1,6 @@
 """
-Levels include (increasing severity): ``DEBUG``, ``INFO``, ``NOTICE``, ``WARNING``, ``ERROR``, ``CRITICAL``, ``DISABLED``
+Levels include (increasing severity): ``DEBUG``, ``INFO``, ``NOTICE``, ``WARNING``, ``ERROR``,
+``CRITICAL``, ``DISABLED``
 """
 
 

--- a/twiggy/levels.py
+++ b/twiggy/levels.py
@@ -2,6 +2,7 @@
 Levels include (increasing severity): ``DEBUG``, ``INFO``, ``NOTICE``, ``WARNING``, ``ERROR``, ``CRITICAL``, ``DISABLED``
 """
 
+
 class LogLevel(object):
     """A log level. Users should *not* create new instances.
 
@@ -20,7 +21,7 @@ class LogLevel(object):
         return self.__name
 
     def __repr__(self):
-        return "<LogLevel %s>"%self.__name
+        return "<LogLevel %s>" % self.__name
 
     def __lt__(self, other):
         if not isinstance(other, LogLevel):
@@ -61,9 +62,11 @@ class LogLevel(object):
     def __hash__(self):
         return hash(self.__value)
 
+
 def name2level(name):
     """return a `LogLevel` from a case-insensitve string"""
     return LogLevel._name2levels[name.upper()]
+
 
 DEBUG = LogLevel('DEBUG', 1)
 INFO = LogLevel('INFO', 2)

--- a/twiggy/lib/__init__.py
+++ b/twiggy/lib/__init__.py
@@ -1,15 +1,17 @@
 import threading
 import time
 
+
 def thread_name():
     """return the name of the current thread"""
     return threading.currentThread().getName()
 
-def iso8601time(gmtime = None):
+
+def iso8601time(gmtime=None):
     """convert time to ISO 8601 format - it sucks less!
-    
-    :arg time.struct_time gmtime: time tuple. If None, use ``time.gmtime()`` (UTC) 
-    
+
+    :arg time.struct_time gmtime: time tuple. If None, use ``time.gmtime()`` (UTC)
+
     XXX timezone is not supported
     """
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", gmtime if gmtime is not None else time.gmtime())

--- a/twiggy/lib/converter.py
+++ b/twiggy/lib/converter.py
@@ -21,7 +21,7 @@ class Converter(object):
 
     :ivar key: the key to apply the conversion to
     :ivar function convert_value: one-argument function to convert the value
-    :ivar function convert_item: two-argument function converting the key & converted value
+    :ivar function convert_item: two-argument function converting the key and converted value
     :ivar bool required: is the item required to present. Items are optional by default.
     """
 
@@ -34,8 +34,8 @@ class Converter(object):
         self.required = required
 
     def __repr__(self):
-        # XXX perhaps poke around in convert_value/convert_item to see if we can extract a meaningful
-        # `"some_string".format`? eh.
+        # XXX perhaps poke around in convert_value/convert_item to see if we can extract
+        # a meaningful `"some_string".format`? eh.
         return "<Converter({0!r})>".format(self.key)
 
 
@@ -46,7 +46,8 @@ class ConversionTable(list):
         """
         :arg seq: a sequence of Converters
 
-        You may also pass 3-or-4 item arg tuples or kwarg dicts (which will be used to create `Converters <.Converter>`)
+        You may also pass 3-or-4 item arg tuples or kwarg dicts (which will be used to create
+        `Converters <.Converter>`)
         """
 
         super(ConversionTable, self).__init__([])
@@ -122,7 +123,11 @@ class ConversionTable(list):
         return [c for c in self if c.key == key]
 
     def add(self, *args, **kwargs):
-        """Append a `.Converter`. ``args`` & ``kwargs`` will be passed through to its constructor"""
+        """
+        Append a `.Converter`.
+
+        ``args`` & ``kwargs`` will be passed through to its constructor
+        """
         self.append(Converter(*args, **kwargs))
 
     def delete(self, key):

--- a/twiggy/lib/converter.py
+++ b/twiggy/lib/converter.py
@@ -5,13 +5,16 @@ def same_value(v):
     """return the value unchanged"""
     return v
 
+
 def same_item(k, v):
     """return the item unchanged"""
     return k, v
 
+
 def drop(k, v):
     """return None, indicating the item should be dropped"""
     return None
+
 
 class Converter(object):
     """Holder for `.ConversionTable` items
@@ -24,7 +27,7 @@ class Converter(object):
 
     __slots__ = ['key', 'convert_value', 'convert_item', 'required']
 
-    def __init__(self, key, convert_value, convert_item, required = False):
+    def __init__(self, key, convert_value, convert_item, required=False):
         self.key = key
         self.convert_value = convert_value
         self.convert_item = convert_item
@@ -34,6 +37,7 @@ class Converter(object):
         # XXX perhaps poke around in convert_value/convert_item to see if we can extract a meaningful
         # `"some_string".format`? eh.
         return "<Converter({0!r})>".format(self.key)
+
 
 class ConversionTable(list):
     """Converts dictionaries using Converters"""
@@ -46,7 +50,8 @@ class ConversionTable(list):
         """
 
         super(ConversionTable, self).__init__([])
-        if seq is None: return
+        if seq is None:
+            return
         for i in seq:
             if isinstance(i, Converter):
                 self.append(i)
@@ -56,7 +61,6 @@ class ConversionTable(list):
                 self.add(**i)
             else:
                 raise ValueError("Bad converter: {0!r}".format(i))
-
         # XXX cache converts & requireds below
 
     @staticmethod

--- a/twiggy/logger.py
+++ b/twiggy/logger.py
@@ -126,7 +126,10 @@ class BaseLogger(object):
 
 
 class InternalLogger(BaseLogger):
-    """Special-purpose logger for internal uses. Sends messages directly to output, bypassing :data:`.emitters`.
+    """
+    Special-purpose logger for internal uses
+
+    Sends messages directly to output, bypassing :data:`.emitters`.
 
     :ivar `Output` output: an output to write to
     """
@@ -148,14 +151,16 @@ class InternalLogger(BaseLogger):
             return
         try:
             try:
-                msg = Message(level, format_spec, self._fields.copy(), self._options.copy(), args, kwargs)
+                msg = Message(level, format_spec, self._fields.copy(), self._options.copy(),
+                              args, kwargs)
             except Exception:
                 msg = None
                 raise
             else:
                 self.output.output(msg)
         except Exception:
-            print(iso8601time(), "Error in twiggy internal log! Something is seriously broken.", file=sys.stderr)
+            print(iso8601time(), "Error in twiggy internal log! Something is seriously broken.",
+                  file=sys.stderr)
             print("Offending message:", repr(msg), file=sys.stderr)
             traceback.print_exc(file=sys.stderr)
 
@@ -175,7 +180,8 @@ class Logger(BaseLogger):
         :arg func: the function to add
         :arg string name: the name to add it under. If None, use the function's name.
         """
-        warnings.warn("Use of features is currently discouraged, pending refactoring", RuntimeWarning)
+        warnings.warn("Use of features is currently discouraged, pending refactoring",
+                      RuntimeWarning)
         name = name if name is not None else func.__name__
         setattr(cls, name, func)
 
@@ -187,7 +193,8 @@ class Logger(BaseLogger):
 
         :arg string name: the name of the feature to disable.
         """
-        warnings.warn("Use of features is currently discouraged, pending refactoring", RuntimeWarning)
+        warnings.warn("Use of features is currently discouraged, pending refactoring",
+                      RuntimeWarning)
         # get func directly from class dict - we don't want an unbound method.
         setattr(cls, name, cls.__dict__['_feature_noop'])
 
@@ -197,7 +204,8 @@ class Logger(BaseLogger):
 
         :arg string name: the name of the feature to remove
         """
-        warnings.warn("Use of features is currently discouraged, pending refactoring", RuntimeWarning)
+        warnings.warn("Use of features is currently discouraged, pending refactoring",
+                      RuntimeWarning)
         delattr(cls, name)
 
     def __init__(self, fields=None, options=None, emitters=None,
@@ -247,10 +255,12 @@ class Logger(BaseLogger):
             if not self.filter(format_spec):
                 return
         except Exception:
-            _twiggy.internal_log.info("Error in Logger filtering with {0} on {1}", repr(self.filter), format_spec)
+            _twiggy.internal_log.info("Error in Logger filtering with {0} on {1}",
+                                      repr(self.filter), format_spec)
             # just continue emitting in face of filter error
 
-            # XXX should we trap here too b/c of "Dictionary changed size during iteration" (or other rare errors?)
+            # XXX should we trap here too b/c of "Dictionary changed size during iteration" (or
+            # other rare errors?)
         potential_emitters = [(name, emitter) for name, emitter in iteritems(self._emitters)
                               if level >= emitter.min_level]
 
@@ -258,11 +268,12 @@ class Logger(BaseLogger):
             return
 
         try:
-            msg = Message(level, format_spec, self._fields.copy(), self._options.copy(), args, kwargs)
+            msg = Message(level, format_spec, self._fields.copy(), self._options.copy(),
+                          args, kwargs)
         except Exception:
             # XXX use .fields() instead?
-            _twiggy.internal_log.info("Error formatting message level: {0!r}, format: {1!r}, fields: {2!r}, "
-                                      "options: {3!r}, args: {4!r}, kwargs: {5!r}",
+            _twiggy.internal_log.info("Error formatting message level: {0!r}, format: {1!r},"
+                                      " fields: {2!r}, options: {3!r}, args: {4!r}, kwargs: {5!r}",
                                       level, format_spec, self._fields, self._options, args, kwargs)
             return
 
@@ -272,8 +283,8 @@ class Logger(BaseLogger):
             try:
                 include = emitter.filter(msg)
             except Exception:
-                _twiggy.internal_log.info("Error filtering with emitter {0}. Filter: {1} Message: {2!r}",
-                                          name, repr(emitter.filter), msg)
+                _twiggy.internal_log.info("Error filtering with emitter {0}. Filter: {1}"
+                                          " Message: {2!r}", name, repr(emitter.filter), msg)
                 include = True  # output anyway if error
 
             if include:

--- a/twiggy/logger.py
+++ b/twiggy/logger.py
@@ -21,12 +21,14 @@ def emit(level):
     ``emit.debug``, ``emit.info``, etc..
 
     """
+
     def decorator(f):
         @wraps(f)
         def wrapper(self, *args, **kwargs):
-            f(self, *args, **kwargs)._emit(level, '', [], {})
+            f(self, * args, ** kwargs)._emit(level, '', [], {})
         return wrapper
     return decorator
+
 
 emit.debug = emit(levels.DEBUG)
 emit.info = emit(levels.INFO)
@@ -35,15 +37,15 @@ emit.warning = emit(levels.WARNING)
 emit.error = emit(levels.ERROR)
 emit.critical = emit(levels.CRITICAL)
 
+
 class BaseLogger(object):
     """Base class for loggers"""
-
 
     __slots__ = ['_fields', '_options', 'min_level']
 
     __valid_options = set(Message._default_options)
 
-    def __init__(self, fields = None, options = None, min_level = None):
+    def __init__(self, fields=None, options=None, min_level=None):
         """Constructor for internal module use only, basically.
 
         ``fields`` and ``options`` will be copied.
@@ -53,12 +55,14 @@ class BaseLogger(object):
         self.min_level = min_level if min_level is not None else levels.DEBUG
 
     def _clone(self):
-        return self.__class__(fields = self._fields, options = self._options, min_level = self.min_level)
+        return self.__class__(fields=self._fields, options=self._options, min_level=self.min_level)
 
     def _emit(self, level, format_spec, args, kwargs):
         raise NotImplementedError
 
-    ## The Magic
+    #
+    # The Magic
+    #
     def fields(self, **kwargs):
         """bind fields for structured logging"""
         return self.fields_dict(kwargs)
@@ -81,7 +85,9 @@ class BaseLogger(object):
         clone._options.update(kwargs)
         return clone
 
-    ##  Convenience
+    #
+    # Convenience
+    #
     def trace(self, trace='error'):
         """convenience method to enable traceback logging"""
         return self.options(trace=trace)
@@ -90,31 +96,34 @@ class BaseLogger(object):
         """convenvience method to bind ``name`` field"""
         return self.fields(name=name)
 
-    ## Do something
-    def debug(self, format_spec = '', *args, **kwargs):
+    #
+    # Do something
+    #
+    def debug(self, format_spec='', *args, **kwargs):
         """Emit at ``DEBUG`` level"""
         self._emit(levels.DEBUG, format_spec, args, kwargs)
 
-    def info(self, format_spec = '', *args, **kwargs):
+    def info(self, format_spec='', *args, **kwargs):
         """Emit at ``INFO`` level"""
         self._emit(levels.INFO, format_spec, args, kwargs)
 
-    def notice(self, format_spec = '', *args, **kwargs):
+    def notice(self, format_spec='', *args, **kwargs):
         """Emit at ``NOTICE`` level"""
         self._emit(levels.NOTICE, format_spec, args, kwargs)
         return True
 
-    def warning(self, format_spec = '', *args, **kwargs):
+    def warning(self, format_spec='', *args, **kwargs):
         """Emit at ``WARNING`` level"""
         self._emit(levels.WARNING, format_spec, args, kwargs)
 
-    def error(self, format_spec = '', *args, **kwargs):
+    def error(self, format_spec='', *args, **kwargs):
         """Emit at ``ERROR`` level"""
         self._emit(levels.ERROR, format_spec, args, kwargs)
 
-    def critical(self, format_spec = '', *args, **kwargs):
+    def critical(self, format_spec='', *args, **kwargs):
         """Emit at ``CRITICAL`` level"""
         self._emit(levels.CRITICAL, format_spec, args, kwargs)
+
 
 class InternalLogger(BaseLogger):
     """Special-purpose logger for internal uses. Sends messages directly to output, bypassing :data:`.emitters`.
@@ -124,19 +133,19 @@ class InternalLogger(BaseLogger):
 
     __slots__ = ['output']
 
-
-    def __init__(self, output, fields = None, options = None, min_level = None):
+    def __init__(self, output, fields=None, options=None, min_level=None):
         super(InternalLogger, self).__init__(fields, options, min_level)
         self.output = output
 
     def _clone(self):
-        return self.__class__(fields = self._fields, options = self._options,
-                              min_level = self.min_level, output = self.output)
+        return self.__class__(fields=self._fields, options=self._options,
+                              min_level=self.min_level, output=self.output)
 
     def _emit(self, level, format_spec, args, kwargs):
         """does work of emitting - for internal use"""
 
-        if level < self.min_level: return
+        if level < self.min_level:
+            return
         try:
             try:
                 msg = Message(level, format_spec, self._fields.copy(), self._options.copy(), args, kwargs)
@@ -146,9 +155,10 @@ class InternalLogger(BaseLogger):
             else:
                 self.output.output(msg)
         except Exception:
-            print(iso8601time(), "Error in twiggy internal log! Something is serioulsy broken.", file=sys.stderr)
+            print(iso8601time(), "Error in twiggy internal log! Something is seriously broken.", file=sys.stderr)
             print("Offending message:", repr(msg), file=sys.stderr)
-            traceback.print_exc(file = sys.stderr)
+            traceback.print_exc(file=sys.stderr)
+
 
 class Logger(BaseLogger):
     """Logger for end-users"""
@@ -190,8 +200,8 @@ class Logger(BaseLogger):
         warnings.warn("Use of features is currently discouraged, pending refactoring", RuntimeWarning)
         delattr(cls, name)
 
-    def __init__(self, fields = None, options = None, emitters = None,
-                 min_level = None, filter = None):
+    def __init__(self, fields=None, options=None, emitters=None,
+                 min_level=None, filter=None):
         super(Logger, self).__init__(fields, options, min_level)
         #: a dict of emitters
         self._emitters = emitters if emitters is not None else {}
@@ -202,9 +212,9 @@ class Logger(BaseLogger):
 
         Probably only for internal use.
         """
-        return self.__class__(fields = self._fields, options = self._options,
-                              emitters = self._emitters, min_level = self.min_level,
-                              filter = self.filter)
+        return self.__class__(fields=self._fields, options=self._options,
+                              emitters=self._emitters, min_level=self.min_level,
+                              filter=self.filter)
 
     @emit.info
     def struct(self, **kwargs):
@@ -223,30 +233,35 @@ class Logger(BaseLogger):
         """
         return self.fields_dict(d)
 
-    ## Boring stuff
+    #
+    # Boring stuff
+    #
     def _emit(self, level, format_spec, args, kwargs):
         """does the work of emitting - for internal use"""
 
         # XXX should these traps be collapsed?
-        if level < self.min_level: return
+        if level < self.min_level:
+            return
 
         try:
-            if not self.filter(format_spec): return
+            if not self.filter(format_spec):
+                return
         except Exception:
             _twiggy.internal_log.info("Error in Logger filtering with {0} on {1}", repr(self.filter), format_spec)
             # just continue emitting in face of filter error
 
-        # XXX should we trap here too b/c of "Dictionary changed size during iteration" (or other rare errors?)
+            # XXX should we trap here too b/c of "Dictionary changed size during iteration" (or other rare errors?)
         potential_emitters = [(name, emitter) for name, emitter in iteritems(self._emitters)
                               if level >= emitter.min_level]
 
-        if not potential_emitters: return
+        if not potential_emitters:
+            return
 
         try:
             msg = Message(level, format_spec, self._fields.copy(), self._options.copy(), args, kwargs)
         except Exception:
             # XXX use .fields() instead?
-            _twiggy.internal_log.info("Error formatting message level: {0!r}, format: {1!r}, fields: {2!r}, "\
+            _twiggy.internal_log.info("Error formatting message level: {0!r}, format: {1!r}, fields: {2!r}, "
                                       "options: {3!r}, args: {4!r}, kwargs: {5!r}",
                                       level, format_spec, self._fields, self._options, args, kwargs)
             return
@@ -259,9 +274,10 @@ class Logger(BaseLogger):
             except Exception:
                 _twiggy.internal_log.info("Error filtering with emitter {0}. Filter: {1} Message: {2!r}",
                                           name, repr(emitter.filter), msg)
-                include = True # output anyway if error
-            
-            if include: outputs.add(emitter._output)
+                include = True  # output anyway if error
+
+            if include:
+                outputs.add(emitter._output)
 
         for o in outputs:
             try:

--- a/twiggy/logging_compat.py
+++ b/twiggy/logging_compat.py
@@ -3,16 +3,19 @@ This module allows replacing stdlib's logging module with twiggy,
 it implements the following interface:
 
 logging's interface:
-  getLogger - returns a logger that supports debug/info/error etc'.
-  root - the root logger.
-  basicConfig - raises an Exception.
+
+    :getLogger: returns a logger that supports debug/info/error etc'.
+    :root: the root logger.
+    :basicConfig: raises an Exception.
 
 hijack interface:
-  hijack - for 'import logging' to import twiggy.
-  restore - for restoring the original logging module.
+
+    :hijack: for 'import logging' to import twiggy.
+    :restore: for restoring the original logging module.
 
 logging bridge:
-  LoggingBridgeOutput - an output that bridges log messages to stdlib's logging.
+
+    :LoggingBridgeOutput: an output that bridges log messages to stdlib's logging.
 """
 import sys
 import logging as orig_logging
@@ -127,13 +130,13 @@ logging_bridge_converter.aggregate = ':'.join
 
 class LoggingBridgeFormat(LineFormat):
     """
-    This logging bridge uses a converter that doesn't display a level, time and name.
-    thats because users of stdlib's logging usually setup formatters that display this info.
+    This logging bridge uses a converter that doesn't display a level, time and name.  That's
+    because users of stdlib's logging usually setup formatters that display this info.
     """
 
     def __init__(self, *args, **kwargs):
         super(LoggingBridgeFormat, self).__init__(conversion=logging_bridge_converter,
-                                                  * args, ** kwargs)
+                                                  *args, **kwargs)
 
     def __call__(self, msg):
         return (super(LoggingBridgeFormat, self).__call__(msg),

--- a/twiggy/message.py
+++ b/twiggy/message.py
@@ -23,11 +23,13 @@ class Message(object):
                  args, kwargs):
         """
         :arg LogLevel level: the level of the message
-        :arg string format_spec: the human-readable message template. Should match the ``style`` in options.
+        :arg string format_spec: the human-readable message template. Should match the ``style``
+            in options.
         :arg dict fields: dictionary of fields for :ref:`structured logging <structured-logging>`
         :arg tuple args: substitution arguments for ``format_spec``.
         :arg dict kwargs: substitution keyword arguments for ``format_spec``.
-        :arg dict options: a dictionary of :ref:`options <message-options>` to control message creation.
+        :arg dict options: a dictionary of :ref:`options <message-options>` to control message
+            creation.
         """
 
         self.fields = fields

--- a/twiggy/message.py
+++ b/twiggy/message.py
@@ -1,10 +1,11 @@
-__all__ = ['Message']
-
 import sys
 import traceback
 from string import Template
 
 from six import iteritems
+
+
+__all__ = ['Message']
 
 
 class Message(object):
@@ -13,10 +14,9 @@ class Message(object):
     __slots__ = ['fields', 'suppress_newlines', 'traceback', 'text']
 
     #: default option values. Don't change these!
-    _default_options = {'suppress_newlines' : True,
-                        'trace' : None,
+    _default_options = {'suppress_newlines': True,
+                        'trace': None,
                         'style': 'braces'}
-
     # XXX I need a __repr__!
 
     def __init__(self, level, format_spec, fields, options,
@@ -34,7 +34,7 @@ class Message(object):
         self.suppress_newlines = options['suppress_newlines']
         self.fields['level'] = level
 
-        ## format traceback
+        # format traceback
         # XXX this needs some cleanup/branch consolidation
         trace = options['trace']
         if isinstance(trace, tuple) and len(trace) == 3:
@@ -56,18 +56,18 @@ class Message(object):
 
         style = options['style']
 
-        style_aliases = {'braces':'braces', 'dollar':'dollar',
-                'percent':'percent', '{}':'braces', '$':'dollar',
-                '%':'percent'}
+        style_aliases = {'braces': 'braces', 'dollar': 'dollar',
+                         'percent': 'percent', '{}': 'braces', '$': 'dollar',
+                         '%': 'percent'}
         try:
             style = style_aliases[style]
         except KeyError:
             raise ValueError("Bad format spec style {0!r}".format(style))
 
-        ## Populate `text` by calling callables in `fields`, `args` and `kwargs`,
-        ## and substituting into `format_spec`.
+        # Populate `text` by calling callables in `fields`, `args` and `kwargs`,
+        # and substituting into `format_spec`.
 
-        ## call any callables
+        # call any callables
         for k, v in iteritems(fields):
             if callable(v):
                 fields[k] = v()
@@ -78,7 +78,7 @@ class Message(object):
 
         args = tuple(v() if callable(v) else v for v in args)
 
-        ## substitute
+        # substitute
         if format_spec == '':
             self.text = ''
             return

--- a/twiggy/outputs.py
+++ b/twiggy/outputs.py
@@ -3,6 +3,7 @@ import threading
 import sys
 import atexit
 
+
 class Output(object):
     """Does the work of formatting and writing a message."""
 
@@ -20,8 +21,8 @@ class Output(object):
         """
         self._format = format if format is not None else self._noop_format
         self._sync_init()
-        
-        if close_atexit: #pragma: no cover
+
+        if close_atexit:  # pragma: no cover
             atexit.register(self.close)
 
     def _sync_init(self):
@@ -59,6 +60,7 @@ class Output(object):
         x = self._format(msg)
         self._write(x)
 
+
 class AsyncOutput(Output):
     """An `.Output` with support for asynchronous logging"""
 
@@ -68,8 +70,8 @@ class AsyncOutput(Output):
             self._sync_init()
         else:
             self._async_init(msg_buffer, close_atexit)
-        
-        if close_atexit: #pragma: no cover
+
+        if close_atexit:  # pragma: no cover
             atexit.register(self.close)
 
     def _async_init(self, msg_buffer, close_atexit):
@@ -77,13 +79,13 @@ class AsyncOutput(Output):
         self.output = self.__async_output
         self.close = self.__async_close
         self.__queue = multiprocessing.JoinableQueue(msg_buffer)
-        self.__child = multiprocessing.Process(target=self.__child_main, args=(self,))
+        self.__child = multiprocessing.Process(target=self.__child_main, args=(self, ))
         self.__child.daemon = not close_atexit
         self.__child.start()
 
     # use a plain function so Windows is cool
     @staticmethod
-    def __child_main(self):            
+    def __child_main(self):
         self._open()
         while True:
             # XXX should _close() be in a finally: ?
@@ -103,7 +105,7 @@ class AsyncOutput(Output):
         self.__queue.put_nowait(msg)
 
     def __async_close(self):
-        self.__queue.put_nowait("SHUTDOWN") # XXX maybe just put?
+        self.__queue.put_nowait("SHUTDOWN")  # XXX maybe just put?
         self.__queue.close()
         self.__queue.join()
 
@@ -122,11 +124,12 @@ class NullOutput(Output):
     def _close(self):
         pass
 
+
 class ListOutput(Output):
     """an output that stuffs messages in a list
-    
+
     Useful for unittesting.
-    
+
     :ivar list messages: messages that have been emitted
     """
 
@@ -147,6 +150,7 @@ class FileOutput(AsyncOutput):
 
     ``name``, ``mode``, ``buffering`` are passed to :func:`open`
     """
+
     def __init__(self, name, format, mode='a', buffering=1, msg_buffer=0, close_atexit=True):
         self.filename = name
         self.mode = mode
@@ -162,11 +166,13 @@ class FileOutput(AsyncOutput):
     def _write(self, x):
         self.file.write(x)
 
+
 class StreamOutput(Output):
     """Output to an externally-managed stream."""
+
     def __init__(self, format, stream=sys.stderr):
         self.stream = stream
-        super(StreamOutput, self).__init__(format, False) # close_atexit makes no sense here
+        super(StreamOutput, self).__init__(format, False)  # close_atexit makes no sense here
 
     def _open(self):
         pass

--- a/twiggy/outputs.py
+++ b/twiggy/outputs.py
@@ -17,7 +17,8 @@ class Output(object):
     def __init__(self, format=None, close_atexit=True):
         """
         :arg format format: the format to use. If None, return the message unchanged.
-        :arg bool close_atexit: should :meth:`.close` be registered with :mod:`atexit`. If False, the user is responsible for closing the output.
+        :arg bool close_atexit: should :meth:`.close` be registered with :mod:`atexit`. If False,
+            the user is responsible for closing the output.
         """
         self._format = format if format is not None else self._noop_format
         self._sync_init()


### PR DESCRIPTION
This PR builds on top of the pyflakes fixes in PR #66 to complete the changes that are needed for flake8 to pass on the tests and twiggy directories.

I've separated the fixes into two commits but you can squash them on merging.  The two new commits are:
* https://github.com/wearpants/twiggy/commit/83333dbccc3fba10d662cb62e43c6a2d1f83e6c7  Fixes the majority of the PEP8 complaints
* https://github.com/wearpants/twiggy/commit/38071745955628185e3a3beca09adbcf9e075bbb Fixes line to long warnings

I separated them for review because fixing the line too long warnings sometimes makes the code uglier in my opinion.  I didn't want to predjudice the first class of fixes with the second ;-)  If you like both sets of changes feel free to squash.  If you don't like the line too long changes we can do something like configure flake8 to give us a longer line length (Raymond Hettinger recommends around 100 characters) or have it disable that check altogether.