### PR TITLE
Travis config to deploy to testpypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,14 @@ install:
 
 script:
   - tox
+
+deploy:
+  provider: pypi
+  distributions: "sdist bdist_wheel"
+  on:
+    branch: master
+    tags: true
+  server: https://test.pypi.org/legacy/
+  user: twiggy-uploader
+  password:
+    secure: V+SEJ++XHtLQGTpuoIm1jIKzCAnSQIuEt8G26YsCkWiZPifUIkfGT4UutGUh+dU0qZu2GOZPY4kpO0UdZvZrPaj1545krBJX3TMgnL0Z6l8Pj0fzQB6Z8/NDZKpNsaZAOcyXP02rXoodeFJrxT4DBUjqZgd6UutxQdlMzsNiurCcTnQTWUrvBm9WTbSIwHO41Go8Ay3E33s2Q6BvyB8DDEzh4YzqWHJU0Vo5tKS/i5zGXNBSCMopeP8VoYisfmYg6mCqBwa03siokKeBk3Zwp1TQcG19Egz8wzLoUNY56HTD/CCTo+7wt/ryOC8bjrxVVAV5WzETf6J4XXEuOYaoOlazccHA/nGKL2pDrFDXdR+J3+mclUESk8Feh01XpYBPfRNkJgVyCQm/c1C43VlFd6aZEiZFNjWb4iwnYEd951gf4NmLoQWM9H11sQPLHDCvEYCJdDdtgVU4Hy6JQrkXZYfPXWHq8D8JlPU42oWp4MIVlr4zFXDIoKYjpSAGJO20NmuSmE3lFdYpNcJWUo2cTFKb2M+KLkd49aCWrCrjAnM5WYyucjzv0VoHBBF+i2zGx9mPfzgWSFxqtJQAW2lv4KkIc0sENSDZvR5vMVvOnhiUuaKgQdotzEfnNXh0ojHS8qCxB1Ux6KKwYR54nX0vX/XdI03msdJKy1QB4nkrvdc=

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+try:
+    # Have to use setuptools to build wheels
+    from setuptools import setup
+except ImporError:
+    from distutils.core import setup
 import os.path
 import sys
 


### PR DESCRIPTION
Implementation of the Pypi portion of #70.  This commit uses the
test.pypi.org server rather than the real server.  When we're satisfied
that this does the right thing we'll need to switch over.

### What's left to do:
* Create a twiggy-uploader user on the real https://pypi.org/
* Grant maintainer status to twiggy-uploader on pypi.python.org so that it can upload to pypi.
* Add the twiggy-uploader password to the .travis.yml file
  * Use  ```travis encrypt --add deploy.password``` to encrypt the new password

### Release procedure:
* Make final changes for the release
* git push
* Check that the commit passes in travis
* git tag $RELEASE
* git push --tags

Note that travis will upload to pypi as soon as the first test passes in travis.  So you don't want to push the tags until travis has run over the commit once and shows that the build passed (in case one test passes but other tests fail)