### PR TITLE
Remove duplicate travis runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,6 @@ matrix:
       env: TOXENV=py26
     - python: 2.7
       env: TOXENV=py27
-    - python: pypy
-      env: TOXENV=pypy
-    - python: pypy3
-      env: TOXENV=pypy3
 
 install:
   - travis_retry pip install tox


### PR DESCRIPTION
We had duplicate entries for pypy and pypy3.  Removing those to save
a little time