### PR TITLE
Fix circular imports

### DIFF
--- a/twiggy/__init__.py
+++ b/twiggy/__init__.py
@@ -33,19 +33,15 @@ def _populate_globals():
 
     emitters = log._emitters
 
-    __internal_format = formats.LineFormat(conversion=formats.line_conversion)
-    __internal_output = outputs.StreamOutput(format=__internal_format, stream=sys.stderr)
-
-    internal_log = logger.InternalLogger(fields=__fields, output=__internal_output
-                                         ).name('twiggy.internal').trace('error')
+    internal_log = logger.internal_log
 
     devel_log = logger.InternalLogger(fields=__fields, output=outputs.NullOutput()
                                       ).name('twiggy.devel')
 
 
 def _del_globals():
-    global __fields, log, emitters, __internal_format, __internal_output, internal_log, devel_log
-    del __fields, log, emitters, __internal_format, __internal_output, internal_log, devel_log
+    global __fields, log, emitters, internal_log, devel_log
+    del __fields, log, emitters, internal_log, devel_log
 
 
 if not os.environ.get('TWIGGY_UNDER_TEST', None):  # pragma: no cover

--- a/twiggy/lib/validators.py
+++ b/twiggy/lib/validators.py
@@ -3,7 +3,8 @@ from collections import Mapping, Sequence
 from six import integer_types, string_types
 from six.moves import builtins
 
-import twiggy
+from .. import formats
+from .. import levels
 
 
 def _import_module(module_name):
@@ -182,7 +183,7 @@ def _validate_config(config):
         raise ValueError("`outputs` must be a dict mapping output_names to outputs")
 
     for output_name, output in config['outputs'].items():
-        new_output = {'args': [], 'kwargs': {}, 'format': twiggy.formats.line_format}
+        new_output = {'args': [], 'kwargs': {}, 'format': formats.line_format}
 
         if not isinstance(output, Mapping):
             raise ValueError("`outputs` must be a dict of dicts")
@@ -225,13 +226,13 @@ def _validate_config(config):
             raise ValueError("Every entry in `emitters` must contain a `level` field")
         if isinstance(emitter['level'], string_types):
             try:
-                level = twiggy.levels.name2level(emitter['level'])
+                level = levels.name2level(emitter['level'])
             except KeyError:
                 raise ValueError("The `level` field of `emitters` must be the string name of"
                                  " a twiggy log level")
         else:
             level = emitter['level']
-        if not isinstance(level, twiggy.levels.LogLevel):
+        if not isinstance(level, levels.LogLevel):
             raise ValueError("The `level` field of `emitters` must be a string naming"
                              " a Twiggy LogLevel")
         new_emitter['level'] = level


### PR DESCRIPTION
Circular imports were preventing twiggy from working when it was installed in non-development mode.